### PR TITLE
Serve GitHub pages from docs folder of master branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+github:
+  ghp_branch:  master
+  ghp_path:    /docs


### PR DESCRIPTION
GH pages is currently configured to serve the gh-pages branch. This is somewhat inconvenient given it requires branch protection rules and needs to be in sync with master anyway (every chart update requires a corresponding package to be published).

This PR changes the repository configuration to publish from the docs directory in master, enabling PRs to be self-contained and automatically published when merged.

`.asf.yaml` content follows the guidance at https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories#id-.asf.yamlfeaturesforgitrepositories-GitHubPages.
