### PR TITLE
Enforce consistent UUID

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -95,17 +95,27 @@ $ helm upgrade my-release couchdb/couchdb
 The following table lists the most commonly configured parameters of the
 CouchDB chart and their default values:
 
-|           Parameter             |             Description                               |                Default                 |
-|---------------------------------|-------------------------------------------------------|----------------------------------------|
-| `clusterSize`                   | The initial number of nodes in the CouchDB cluster    | 3                                      |
-| `couchdbConfig`                 | Map allowing override elements of server .ini config  | chttpd.bind_address=any                |
-| `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
-| `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
-| `schedulerName`                 | Name of the k8s scheduler (other than default)        | `nil`                                  |
-| `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster
-| `persistentVolume.enabled`      | Boolean determining whether to attach a PV to each node | false
-| `persistentVolume.size`         | If enabled, the size of the persistent volume to attach                          | 10Gi
-| `enableSearch`                  | Adds a sidecar for Lucene-powered text search         | false                                  |
+|           Parameter             |             Description                                 |                Default                 |
+|---------------------------------|---------------------------------------------------------|----------------------------------------|
+| `clusterSize`                   | The initial number of nodes in the CouchDB cluster      | 3                                      |
+| `couchdbConfig`                 | Map allowing override elements of server .ini config    | *See below*                            |
+| `allowAdminParty`               | If enabled, start cluster without admin account         | false (requires creating a Secret)     |
+| `createAdminSecret`             | If enabled, create an admin account and cookie secret   | true                                   |
+| `schedulerName`                 | Name of the k8s scheduler (other than default)          | `nil`                                  |
+| `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM       | name: couchdb, setcookie: monster      |
+| `persistentVolume.enabled`      | Boolean determining whether to attach a PV to each node | false                                  |
+| `persistentVolume.size`         | If enabled, the size of the persistent volume to attach | 10Gi                                   |
+| `enableSearch`                  | Adds a sidecar for Lucene-powered text search           | false                                  |
+
+You can set the values of the `couchdbConfig` map according to the 
+[official configuration][4]. The following shows the map's default values and 
+most important options to set:
+
+|           Parameter             |             Description                                            |                Default                 |
+|---------------------------------|--------------------------------------------------------------------|----------------------------------------|
+| `chttpd.bind_address`           | listens on all interfaces when set to any                          | any                                    |
+| `chttpd.require_valid_user`     | disables all the anonymous requests to the port 5984 when true     | false                                  |
+| `couchdb.uuid`                  | UUID for this CouchDB server instance ([Required in a cluster][5]) | *\<random UUID\>*                               |
 
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
@@ -175,3 +185,5 @@ use GitHub Issues, do not report anything on Docker's website.
 [1]: http://mail-archives.apache.org/mod_mbox/couchdb-user/
 [2]: http://mail-archives.apache.org/mod_mbox/couchdb-dev/
 [3]: https://github.com/apache/couchdb/blob/master/CONTRIBUTING.md
+[4]: https://docs.couchdb.org/en/stable/config/index.html
+[5]: https://docs.couchdb.org/en/latest/setup/cluster.html#preparing-couchdb-nodes-to-be-joined-into-a-cluster

--- a/couchdb/templates/_helpers.tpl
+++ b/couchdb/templates/_helpers.tpl
@@ -72,3 +72,14 @@ If serviceAccount.name is specified, use that, else use the couchdb instance nam
 {{- template "couchdb.fullname" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+If couchdbConfig.couchdb.uuid is specified, use that, else generate a UUID
+*/}}
+{{- define "couchdb.uuid" -}}
+{{- if  (.Values.couchdbConfig.couchdb | default dict).uuid -}}
+{{- .Values.couchdbConfig.couchdb.uuid }}
+{{- else -}}
+{{- uuidv4 | replace "-" "" -}}
+{{- end -}}
+{{- end -}}

--- a/couchdb/templates/configmap.yaml
+++ b/couchdb/templates/configmap.yaml
@@ -9,7 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
 data:
   inifile: |
-    {{ range $section, $settings := .Values.couchdbConfig -}}
+    {{ $couchdbConfig := dict "couchdb" (dict "uuid" (include "couchdb.uuid" .)) }}
+    {{ $couchdbConfig := merge $couchdbConfig .Values.couchdbConfig  }}
+    {{ range $section, $settings := $couchdbConfig -}}
     {{ printf "[%s]" $section }}
     {{ range $key, $value := $settings -}}
     {{ printf "%s = %s" $key ($value | toString) }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -150,6 +150,9 @@ erlangFlags:
 ## by a ConfigMap object.
 ## ref: http://docs.couchdb.org/en/latest/config/index.html
 couchdbConfig:
+  # couchdb:
+  #  uuid: decafbaddecafbaddecafbaddecafbad # Unique identifier for this CouchDB server instance
+
   # cluster:
   #   q: 8 # Create 8 shards for each database
   chttpd:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR does two things:

1. It generates a random UUID in case `couchdbConfig.couchdb.uuid` is not passed as a value.
2. It documents the option and references the documentation

The option is mandatory since replication issues (See apache/couchdb#2298) can occur when all instances have different UUIDs which is what happens when `couchdbConfig.couchdb.uuid` is not set.

#### Which issue this PR fixes

- fixes helm/charts#13481

#### Special notes for your reviewer:

Since every subsequent helm execution (i.e. upgrade) will generate a new UUID, it would be best if the user sets the UUID as a value herself. Should this be more clear in the documentation?

#### Checklist

- [ ] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated