### PR TITLE
Fix overwriting created date for old chart versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ lint:
 
 .PHONY: publish
 publish: lint
-	@helm package couchdb -d docs
-	@helm repo index docs --url https://apache.github.io/couchdb-helm
+	@mkdir -p new_charts
+	@helm package -u -d new_charts couchdb
+	@helm repo index --url "https://apache.github.io/couchdb-helm" --merge docs/index.yaml new_charts
+	@mv new_charts/couchdb*.tgz docs
+	@mv new_charts/index.yaml docs/index.yaml
+	@rm -rf new_charts
 
 # Run end to end tests using KinD
 .PHONY: test


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

By default, `helm repo index` will update all `created` date fields
in the index to the current date. This results in us losing the
creation dates for old chart versions.

One workaround is to create an index with only the new chart version
and merge this with the existing index. This commit updates
`make publish` to do that.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
