### PR TITLE
Enable splitting view storage and databases

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -174,6 +174,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `service.enabled`                    | true                                   |
 | `service.type`                       | ClusterIP                              |
 | `service.externalPort`               | 5984                                   |
+| `splitStorage.enabled`               | false                                  |
 | `dns.clusterDomainSuffix`            | cluster.local                          |
 | `networkPolicy.enabled`              | true                                   |
 | `serviceAccount.enabled`             | true                                   |

--- a/couchdb/templates/configmap.yaml
+++ b/couchdb/templates/configmap.yaml
@@ -11,6 +11,9 @@ data:
   inifile: |
     {{ $couchdbConfig := dict "couchdb" (dict "uuid" (include "couchdb.uuid" .)) -}}
     {{- $couchdbConfig := merge $couchdbConfig .Values.couchdbConfig -}}
+    {{- if .Values.splitStorage.enabled -}}
+    {{- $couchdbConfig := merge $couchdbConfig (dict "couchdb" (dict "view_index_dir" "./view-data")) -}}
+    {{- end -}}
     {{- range $section, $settings := $couchdbConfig -}}
     {{ printf "[%s]" $section }}
     {{ range $key, $value := $settings -}}

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -114,6 +114,10 @@ spec:
             mountPath: /opt/couchdb/etc/default.d
           - name: database-storage
             mountPath: /opt/couchdb/data
+{{- if .Values.splitStorage.enabled }}
+          - name: view-index-storage
+            mountPath: /opt/couchdb/view-data
+{{- end }}
 {{- if .Values.enableSearch }}
         - name: clouseau
           image: "{{ .Values.searchImage.repository }}:{{ .Values.searchImage.tag }}"
@@ -149,6 +153,10 @@ spec:
 {{- if not .Values.persistentVolume.enabled }}
         - name: database-storage
           emptyDir: {}
+{{- if .Values.splitStorage.enabled }}
+        - name: view-index-storage
+          emptyDir: {}
+{{- end }}
 {{- else }}
   volumeClaimTemplates:
     - metadata:
@@ -171,4 +179,26 @@ spec:
         storageClassName: "{{ .Values.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
+{{- if .Values.splitStorage.enabled }}
+    - metadata:
+        name: view-index-storage
+        labels:
+          app: {{ template "couchdb.name" . }}
+          release: {{ .Release.Name }}
+      spec:
+        accessModes:
+        {{- range .Values.persistentVolume.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistentVolume.size | quote }}
+      {{- if .Values.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
+{{- end }}
 {{- end }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -55,6 +55,10 @@ persistentVolume:
   size: 10Gi
   # storageClass: "-"
 
+## If enabled the databases and view storage are written to separate volumes
+splitStorage:
+  enabled: false
+
 ## The CouchDB image
 image:
   repository: couchdb


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows splitting the storage volumes into a view index dir and a data dir for greater performance.

#### Checklist

- [ ] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated