### PR TITLE
Role bindings

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -179,6 +179,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `serviceAccount.enabled`             | true                                   |
 | `serviceAccount.create`              | true                                   |
 | `serviceAccount.imagePullSecrets`    |                                        |
+| `serviceAccount.roles`               | []                                     |
 | `livenessProbe.enabled`              | true                                   |
 | `livenessProbe.failureThreshold`     | 3                                      |
 | `livenessProbe.initialDelaySeconds`  | 0                                      |

--- a/couchdb/templates/roles.yaml
+++ b/couchdb/templates/roles.yaml
@@ -1,0 +1,18 @@
+{{- $root := . -}}
+{{- range $role := .Values.serviceAccount.roles }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+{{ toYaml $role }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $role.metadata.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $role.metadata.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "couchdb.serviceAccount" $root }}
+{{- end }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -39,6 +39,13 @@ networkPolicy:
 serviceAccount:
   enabled: true
   create: true
+  roles: []
+    # - metadata:
+    #     name: endpoint-access
+    #   rules:
+    #     - apiGroups: [""]
+    #       resources: ["endpoints"]
+    #       verbs: ["*"]
 # name:
 # imagePullSecrets:
 # - name: myimagepullsecret


### PR DESCRIPTION
#### What this PR does / why we need it:

The sidecar containers I added with #21 might need special roles and role bindings to perform their work. For instance we grant our backup sidecar container access to endpoint resources of the namespace for the sidecar containers to perform a leader election. This PR thus allows the setup of arbitrary roles and role bindings for the service account that the stateful set uses.

#### Checklist

- [ ] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
