### PR TITLE
Allow setting of consistent admin password hash

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -59,6 +59,23 @@ Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
 $  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
 ```
 
+If you want to set the `adminHash` directly to achieve consistent salts between 
+different nodes you need to addionally add the key `password.ini` to the secret:
+
+```bash
+$  kubectl create secret generic my-release-couchdb \
+   --from-literal=adminUsername=foo \
+   --from-literal=cookieAuthSecret=baz \
+   --from-file=./my-password.ini 
+```
+
+With the following contents in `my-password.ini`:
+
+```
+[admins]
+foo = <pbkdf2-hash>
+```
+
 and then install the chart while overriding the `createAdminSecret` setting:
 
 ```bash
@@ -148,6 +165,7 @@ A variety of other parameters are also configurable. See the comments in the
 |--------------------------------------|----------------------------------------|
 | `adminUsername`                      | admin                                  |
 | `adminPassword`                      | auto-generated                         |
+| `adminHash`                          |                                        |
 | `cookieAuthSecret`                   | auto-generated                         |
 | `image.repository`                   | couchdb                                |
 | `image.tag`                          | 2.3.1                                  |

--- a/couchdb/password.ini
+++ b/couchdb/password.ini
@@ -1,0 +1,2 @@
+[admins]
+{{ .Values.adminUsername }} = {{ .Values.adminHash }}

--- a/couchdb/templates/secrets.yaml
+++ b/couchdb/templates/secrets.yaml
@@ -13,4 +13,7 @@ data:
   adminUsername: {{ template "couchdb.defaultsecret" .Values.adminUsername }}
   adminPassword: {{ template "couchdb.defaultsecret" .Values.adminPassword }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
+{{- if  .Values.adminHash  }}
+  password.ini: {{ tpl (.Files.Get "password.ini") . | b64enc }}
+{{- end -}}
 {{- end -}}

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -39,6 +39,18 @@ spec:
             mountPath: /tmp/
           - name: config-storage
             mountPath: /default.d
+{{- if .Values.adminHash }}
+        - name: admin-hash-copy
+          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command: ['sh','-c','cp /tmp/password.ini /local.d/ ;']
+          volumeMounts:
+            - name: admin-password
+              mountPath: /tmp/password.ini
+              subPath: "password.ini"
+            - name: local-config-storage
+              mountPath: /local.d
+{{- end }}
       containers:
         - name: couchdb
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -112,6 +124,10 @@ spec:
           volumeMounts:
           - name: config-storage
             mountPath: /opt/couchdb/etc/default.d
+{{- if .Values.adminHash }}
+          - name: local-config-storage
+            mountPath: /opt/couchdb/etc/local.d
+{{- end }}
           - name: database-storage
             mountPath: /opt/couchdb/data
 {{- if .Values.enableSearch }}
@@ -145,6 +161,14 @@ spec:
                 path: chart.ini
               - key: seedlistinifile
                 path: seedlist.ini
+
+{{- if .Values.adminHash }}
+        - name: local-config-storage
+          emptyDir: {}
+        - name: admin-password
+          secret:
+            secretName: {{ template "couchdb.fullname" . }}
+{{- end -}}
 
 {{- if not .Values.persistentVolume.enabled }}
         - name: database-storage

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -13,9 +13,10 @@ allowAdminParty: false
 ## be created containing auto-generated credentials. Users who prefer to set
 ## these values themselves have a couple of options:
 ##
-## 1) The `adminUsername`, `adminPassword`, and `cookieAuthSecret` can be
-##    defined directly in the chart's values. Note that all of a chart's values
-##    are currently stored in plaintext in a ConfigMap in the tiller namespace.
+## 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`
+##    can be defined directly in the chart's values. Note that all of a chart's
+##    values are currently stored in plaintext in a ConfigMap in the tiller
+##    namespace.
 ##
 ## 2) This flag can be disabled and a Secret with the required keys can be
 ##    created ahead of time.
@@ -23,6 +24,7 @@ createAdminSecret: true
 
 adminUsername: admin
 # adminPassword: this_is_not_secure
+# adminHash: -pbkdf2-this_is_not_necessarily_secure_either
 # cookieAuthSecret: neither_is_this
 
 ## When enabled, will deploy a networkpolicy that allows CouchDB pods to
@@ -129,7 +131,8 @@ ingress:
 
 ## Optional resource requests and limits for the CouchDB container
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources: {}
+resources:
+  {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
@@ -159,7 +162,6 @@ couchdbConfig:
     # chttpd.require_valid_user disables all the anonymous requests to the port
     # 5984 when is set to true.
     require_valid_user: false
-
 
 # Kubernetes local cluster domain.
 # This is used to generate FQDNs for peers when joining the CouchDB cluster.


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows the usage of a hash for the admin user instead of a password which will ensure that the admin hash is consistent between different nodes. This circumvents the problem described in apache/couchdb#1781.

#### Checklist

- [ ] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
