### PR TITLE
Handle when chttpd.require_valid_user_except_for_up is set to true

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 3.3.0
+version: 3.3.1
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
 {{ include "couchdb.ss.selector" . | indent 8 }}
 {{- with .Values.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -88,10 +88,10 @@ spec:
               command:
                 - sh
                 - -c
-                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/
+                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/_up
 {{- else }}
             httpGet:
-              path: /
+              path: /_up
               port: 5984
 {{- end }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}


### PR DESCRIPTION
K8s will fail if liveness is not pointing to the `_up` endpoint
