### PR TITLE
Add PodSecurityPolicy

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -194,6 +194,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `service.externalPort`               | 5984                                   |
 | `dns.clusterDomainSuffix`            | cluster.local                          |
 | `networkPolicy.enabled`              | true                                   |
+| `podSecurityPolicy.enabled`          | false                                  |
 | `serviceAccount.enabled`             | true                                   |
 | `serviceAccount.create`              | true                                   |
 | `serviceAccount.imagePullSecrets`    |                                        |

--- a/couchdb/templates/psp-clusterrole.yaml
+++ b/couchdb/templates/psp-clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "couchdb.fullname" . }}-psp
+  labels:
+    app: {{ include "couchdb.name" . }}
+    app.kubernetes.io/name: {{ include "couchdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "couchdb.fullname" . }}
+{{- end }}

--- a/couchdb/templates/psp-clusterrolebinding.yaml
+++ b/couchdb/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "couchdb.fullname" . }}-psp
+  labels:
+    app: {{ include "couchdb.name" . }}
+    app.kubernetes.io/name: {{ include "couchdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "couchdb.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "couchdb.serviceAccount" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/couchdb/templates/psp.yaml
+++ b/couchdb/templates/psp.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ include "couchdb.name" . }}
+    app.kubernetes.io/name: {{ include "couchdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []  # default set of capabilities are implicitly allowed
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+{{- end }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -37,6 +37,11 @@ networkPolicy:
 ##
 # schedulerName:
 
+## When enabled, will deploy PodSecurityPolicy, ClusterRole and ClusterRoleBinding.
+## Requires serviceAccount to be enabled as well.
+podSecurityPolicy:
+  enabled: false
+
 # Use a service account
 serviceAccount:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Some environments enforce PodSecurityPolicy checks
and deployment fails if objects PodSecurityPolicy, ClusterRole and ClusterRoleBinding are not declared.

This commit adds PodSecurityPolicy, ClusterRole and ClusterRoleBinding
objects and adds new configuration option `podSecurityPolicy`, which is
disabled by default.

#### Which issue this PR fixes

<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
