### PR TITLE
Add doc to use Authenticate Basic with require_valid_user

### DIFF
--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -162,6 +162,10 @@ couchdbConfig:
     # chttpd.require_valid_user disables all the anonymous requests to the port
     # 5984 when is set to true.
     require_valid_user: false
+  # required to use Fauxton if chttpd.require_valid_user is set to true
+  # httpd:
+  #   WWW-Authenticate: "Basic realm=\"administrator\""
+    
 
 # Kubernetes local cluster domain.
 # This is used to generate FQDNs for peers when joining the CouchDB cluster.


### PR DESCRIPTION
#### What this PR does / why we need it:
Add comment to use  Authenticate Basic when using require_valid_user = true.
This is documented in the official documentation but it's handy to have it here.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

Relates to: https://github.com/apache/couchdb/issues/1305

#### Checklist
N/A