### PR TITLE
Cluster setup

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 3.3.3
+version: 3.4.0
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -142,6 +142,7 @@ CouchDB chart and their default values:
 | `couchdbConfig`                 | Map allowing override elements of server .ini config  | *See below*                            |
 | `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
 | `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
+| `clusterSetup`                  | Finalize cluster configuration by calling /_cluster_setup endpoint after installation | false  |
 | `schedulerName`                 | Name of the k8s scheduler (other than default)        | `nil`                                  |
 | `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster
 | `persistentVolume.enabled`      | Boolean determining whether to attach a PV to each node | false

--- a/couchdb/templates/NOTES.txt
+++ b/couchdb/templates/NOTES.txt
@@ -2,13 +2,12 @@ Apache CouchDB is starting. Check the status of the Pods using:
 
   kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "couchdb.name" . }},release={{ .Release.Name }}"
 
-Once all of the Pods are fully Ready, execute the following command to create
+Once all of the pods are fully ready, execute the following command to create
 some required system databases:
 
   kubectl exec --namespace {{ .Release.Namespace }} {{ if not .Values.allowAdminParty }}-it {{ end }}{{ template "couchdb.fullname" . }}-0 -c couchdb -- \
     curl -s \
     http://127.0.0.1:5984/_cluster_setup \
-    -X POST \
     -H "Content-Type: application/json" \
 {{- if .Values.allowAdminParty }}
     -d '{"action": "finish_cluster"}'
@@ -18,3 +17,6 @@ some required system databases:
 {{- end }}
 
 Then it's time to relax.
+
+As of chart version 3.4.0, the helm chart will attempt automatically to complete
+cluster setup after installation if the `clusterSetup` value is set to true.

--- a/couchdb/templates/clustersetup.yaml
+++ b/couchdb/templates/clustersetup.yaml
@@ -1,0 +1,76 @@
+{{ if .Values.clusterSetup }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-setup-script
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  setup.sh: |
+    set -e
+    BASE_URL=http://{{ template "couchdb.fullname" . }}:5984
+    set -x
+
+    echo "Waiting for CouchDB service to start..."
+    until curl --silent -max-time 5 --head --fail "${BASE_URL}/_up"; do
+        printf "%s: CouchDB not up yet. Will try again\n" "$(date)"
+        sleep 2
+    done
+
+    echo "Initializing cluster"
+    touch /tmp/curl.cf
+    {{ if not .Values.allowAdminParty }}
+        echo "-u $(cat /tmp/admin-password/adminUsername):$(cat /tmp/admin-password/adminPassword)" >> /tmp/curl.cf
+    {{ end }}
+    curl -silent "${BASE_URL}/_cluster_setup" \
+      -H "Content-Type: application/json" \
+      -d '{"action": "finish_cluster"}' \
+      -K /tmp/curl.cf
+
+    echo "Success!"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-setup-job
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: cluster-setup-job
+      labels:
+        app: {{ template "couchdb.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: admin-password-volume
+          secret:
+            secretName: {{ template "couchdb.fullname" . }}
+        - name: cluster-setup-script-volume
+          configMap:
+            name: cluster-setup-script
+      containers:
+      - name: cluster-setup-job
+        image: "curlimages/curl:7.72.0"
+        command: [ "/bin/sh", "/tmp/setup/setup.sh" ]
+        volumeMounts:
+        - name: admin-password-volume
+          readOnly: true
+          mountPath: /tmp/admin-password
+        - name: cluster-setup-script-volume
+          mountPath: /tmp/setup
+{{ end }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -22,6 +22,8 @@ allowAdminParty: false
 ##    created ahead of time.
 createAdminSecret: true
 
+clusterSetup: false
+
 adminUsername: admin
 # adminPassword: this_is_not_secure
 # adminHash: -pbkdf2-this_is_not_necessarily_secure_either


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the `clusterSetup` variable, which defaults to false. When enabled, a Helm `post-install` hook is initialized which waits for the `_up` endpoint to respond with a 200, then finalizes cluster setup by sending the requisite POST to `/_cluster_setup`.

#### Which issue this PR fixes
Fixes #41 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
