### PR TITLE
No HTTP call to a third-party to generate a random UUID

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -17,7 +17,7 @@ storage volumes to each Pod in the Deployment.
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
   --set allowAdminParty=true \
-  --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
+  --set couchdbConfig.couchdb.uuid=$(( uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid ) | tr "[A-Z]" "[a-z]")
 ```
 
 ## Prerequisites


### PR DESCRIPTION
#### What this PR does / why we need it:

This pull request removes the third-party HTTP call to generate a random UUID, which seems unnecessary.

- uuidgen is by default on Mac.
- On Linux, /proc/sys/kernel/random/uuid contains a random uuid

This may **not** support people using this hem chart through Bash on Windows, I havn't tested. But these people, if they exist, should use WSL or WSL2 instead.


#### Which issue this PR fixes

Fixes nothing.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
