### PR TITLE
Fix broken "make test"

### DIFF
--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -165,7 +165,7 @@ couchdbConfig:
   # required to use Fauxton if chttpd.require_valid_user is set to true
   # httpd:
   #   WWW-Authenticate: "Basic realm=\"administrator\""
-    
+
 
 # Kubernetes local cluster domain.
 # This is used to generate FQDNs for peers when joining the CouchDB cluster.

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need `it:`

`make test` currently fails on a new install because the `apiVersion` is no longer supported (at least with the latest install of `kind`).  Once the `apiVersion` is fixed, there's a linting error picked up by the test in `couchdb/values.yaml` because there's a blank line with several spaces (see the diff).

#### Special notes for your reviewer:
Each of the two minor changes is in a separate and logged commit. I can squash of course.

#### Checklist
- [x] e2e tests pass
