### PR TITLE
Deploy GH Pages from main, add branch protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,12 @@
 github:
-  ghp_branch:  master
+  description: "Apache CouchDB Helm Chart"
+  labels:
+    - couchdb
+    - helm
+    - kubernetes
+  protected_branches:
+    main:
+      required_status_checks:
+        strict: true
+  ghp_branch:  main
   ghp_path:    /docs


### PR DESCRIPTION
#### What this PR does / why we need it:

The Helm index hosted by GH Pages was still pointing at the contents of the master branch so users were missing out on fixes since v3.3.4 of this chart.

#### Which issue this PR fixes
  - fixes #58
