### PR TITLE
Generate a unique Erlang cookie by default

### DIFF
--- a/couchdb/templates/secrets.yaml
+++ b/couchdb/templates/secrets.yaml
@@ -12,6 +12,7 @@ type: Opaque
 data:
   adminUsername: {{ template "couchdb.defaultsecret" .Values.adminUsername }}
   adminPassword: {{ template "couchdb.defaultsecret" .Values.adminPassword }}
+  erlangCookie: {{ template "couchdb.defaultsecret" .Values.erlangFlags.setcookie }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
 {{- if  .Values.adminHash  }}
   password.ini: {{ tpl (.Files.Get "password.ini") . | b64enc }}

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -92,6 +92,11 @@ spec:
                   name: {{ template "couchdb.fullname" . }}
                   key: cookieAuthSecret
 {{- end }}
+            - name: COUCHDB_ERLANG_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: erlangCookie
             - name: ERL_FLAGS
               value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
 {{- if .Values.livenessProbe.enabled }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -152,12 +152,15 @@ resources:
   #  memory: 256Gi
 
 ## erlangFlags is a map that is passed to the Erlang VM as flags using the
-## ERL_FLAGS env. `name` and `setcookie` flags are minimally required to
-## establish connectivity between cluster nodes.
+## ERL_FLAGS env. The `name` flag is required to establish connectivity
+## between cluster nodes.
 ## ref: http://erlang.org/doc/man/erl.html#init_flags
 erlangFlags:
   name: couchdb
-  setcookie: monster
+  # Older versions of the official CouchDB image (anything prior to 3.2.1)
+  # do not act on the COUCHDB_ERLANG_COOKIE environment variable, so if you
+  # want to cluster these deployments it's necessary to pass in a cookie here
+  # setcookie: make-something-up
 
 ## couchdbConfig will override default CouchDB configuration settings.
 ## The contents of this map are reformatted into a .ini file laid down


### PR DESCRIPTION
#### What this PR does / why we need it:

This relies on new support for the `COUCHDB_ERLANG_COOKIE` env to generate a Secret that is written down into ~/.erlang.cookie instead of passing the cookie in the `ERL_FLAGS`. I suppose it would be possible to merge the generated cookie into ERL_FLAGS, but this approach seemed cleaner, more secure, and more maintainable going forward.

#### Special notes for your reviewer:

Will publish the update chart separately, right now I'd like to merge this in part to test a fix for #67 and see if we can get versions up through 3.6.0 published.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [x] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
