### PR TITLE
Create resources for GitHub release backfill

### DIFF
--- a/docs/DEPRECATED.md
+++ b/docs/DEPRECATED.md
@@ -1,0 +1,47 @@
+# Deprecated
+
+Per [this issue](https://github.com/apache/couchdb-helm/issues/62), we plan to move things in `./docs` here
+to GitHub releases and follow the helm community's guidance on 
+release practices for helm charts.
+
+# Migration Path
+
+In order to migrate the old .tgz files, we:
+
+- Will find the latest commit that modified a .tgz
+- Sanity check that `Chart.yaml` represents the same version
+- Forego any further file consistency checks (this is best effort)
+- Presume that the git state matches what is in the .tgz at that time
+- Tag and release the given commit to GitHub Releases using [`chart-releaser`](https://github.com/helm/chart-releaser)
+
+## How To
+
+1. `cd docs` to move into this directory
+2. Install the `chart-releaser` binary (only one architecture defined)
+```bash
+cd docs
+./install-cr.sh
+```
+3. Build an inventory of what .tgz files exist in the directory
+```bash
+./get-inventory.sh
+```
+4. Sanity check that things look appropriate
+```bash
+./check-inventory.sh
+```
+5. Run the release dry-run
+```bash
+# ./release-inventory.sh {{ owner }}
+# i.e.
+./release-inventory.sh colearendt
+```
+6. Check that things look good, then run the actual release process
+```bash
+# ./release-inventory.sh {{ owner }} execute
+# (see docs for more info / other args)
+# i.e.
+./release-inventory.sh colearendt execute
+```
+
+NOTE: we have not done anything to sign chart packages here, though `chart-releaser` supports doing so.

--- a/docs/check-inventory.sh
+++ b/docs/check-inventory.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+found_probs=0
+cat inventory.txt | while read line; do
+  tarball=$(echo $line | cut -d: -f 1)
+  gitsha=$(echo $line | cut -d' ' -f 2)
+  cversion=${tarball/couchdb-/}
+  cversion=${cversion/.tgz/}
+  echo "--> Checking that '$gitsha' matches chart version '$cversion'";
+  
+  cversion_actual=$(git show $gitsha:../couchdb/Chart.yaml | grep '^version:')
+  diff <(echo "$cversion_actual") <(echo "version: $cversion")
+  res=$?
+  if [[ $res -gt 0 ]]; then
+    echo "--> Uh oh! Git SHA '$gitsha' provided version '$cversion_actual', but tarball had '$cversion'"
+    found_probs=1
+  fi;
+
+  # TODO: could check that file SHAs match w/ the tarballs... but this is a best effort anyways...
+done
+
+echo
+if [[ found_probs -eq 0 ]]; then
+  echo '--> Success! All checks went well!'
+else
+  echo '--> PROBLEMS FOUND!'
+fi

--- a/docs/get-inventory.sh
+++ b/docs/get-inventory.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+echo '--> Clearing past inventory.txt'
+rm -f inventory.txt
+
+echo '--> Building inventory.txt with files and commits'
+
+# generate the list of backfill commits
+# assuming that the commit that added the tarball also has the appropriate state committed to the repo
+for f in `ls . | grep -v '.*backfill.*' | grep -v '.*inventory.*' | grep -v '.*index.*'`; do echo $f: `git log --oneline -- $f | head -1` >> inventory.txt; done
+
+echo '--> Done!'

--- a/docs/get-inventory.sh
+++ b/docs/get-inventory.sh
@@ -9,6 +9,8 @@ echo '--> Building inventory.txt with files and commits'
 
 # generate the list of backfill commits
 # assuming that the commit that added the tarball also has the appropriate state committed to the repo
-for f in `ls . | grep -v '.*backfill.*' | grep -v '.*inventory.*' | grep -v '.*index.*'`; do echo $f: `git log --oneline -- $f | head -1` >> inventory.txt; done
+for f in `ls . | grep 'couchdb-.*\.tgz'`; do
+  echo $f: `git log --oneline -- $f | head -1` >> inventory.txt;
+done
 
 echo '--> Done!'

--- a/docs/install-cr.sh
+++ b/docs/install-cr.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+os=$(uname -p)
+arch=$(uname -s)
+if [[ "${os}" == "arm" ]] && [[ "${arch}" == "Darwin" ]]; then
+  mkdir -p ./bin/cr-1.4.0/
+  curl -L https://github.com/helm/chart-releaser/releases/download/v1.4.0/chart-releaser_1.4.0_darwin_arm64.tar.gz | tar -xzvf - -C ./bin/cr-1.4.0/
+  ln -f -s $PWD/bin/cr-1.4.0/cr $PWD/bin/cr
+  echo "Installed successfully!"
+else
+  echo "ERROR: OS '${os}' and Architecture '${arch}' not defined"
+  echo "Visit https://github.com/helm/chart-releaser/releases to see releases"
+fi

--- a/docs/inventory.txt
+++ b/docs/inventory.txt
@@ -1,0 +1,19 @@
+couchdb-2.2.0.tgz: 3e2f02e Address review comments
+couchdb-2.3.0.tgz: 40832bb Add configurable path
+couchdb-2.4.0.tgz: d6fec58 Bump chart version to 2.4.0
+couchdb-2.4.1.tgz: ad5417d Bugfix: fixes wrong Values iteration in ingress host
+couchdb-3.0.0.tgz: b46f424 Require a server instance UUID (#15)
+couchdb-3.1.0.tgz: bbf7201 Bump chart version
+couchdb-3.2.0.tgz: d8a2194 Bump chart version to 3.2.0
+couchdb-3.3.0.tgz: bb17404 Prehashed pw (#26)
+couchdb-3.3.1.tgz: 832994c Publish 3.3.1 chart
+couchdb-3.3.2.tgz: fc411c1 Update chart and index
+couchdb-3.3.3.tgz: da1d946 Bump chart version and publish
+couchdb-3.3.4.tgz: a75233c Bump default CouchDB version to 3.1.1
+couchdb-3.4.0.tgz: 252e73b Bump chart to 3.4.0 CouchDB to 3.2.0
+couchdb-3.4.1.tgz: 6e46579 Publish updated chart
+couchdb-3.5.0.tgz: 9f10dad Add topologySpreadConstraints parameter to be used in StatefulSet (#59)
+couchdb-3.5.1.tgz: e727842 Bump chart version and publish
+couchdb-3.5.2.tgz: dc2899b Bump chart version and publish
+couchdb-3.6.0.tgz: 22761f9 Add helm post-install hook to automate placement tagging in CouchDB nodes (#66)
+couchdb-3.6.1.tgz: bd9bce1 Bump chart version and publish

--- a/docs/release-inventory.sh
+++ b/docs/release-inventory.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Example usage
+#
+#
+# $1 == owner - no default
+# $2 == "execute" makes the release fire!
+# $3 == GitHub auth token. Defaults to the value of $GITHUB_PAT
+# $4 == GitHub repository - defaults to "couchdb-helm"
+
+owner=${1:-}
+execute=${2:-}
+token=${3:-${GITHUB_PAT:-}}
+repo=${4:-couchdb-helm}
+chart_name=${5:-couchdb}
+
+if [[ -z "$owner" ]]; then
+  echo "Error: must provide 'owner' in first argument"
+  exit 1
+fi
+
+echo "Owner: $owner"
+echo "Execute?: $execute"
+
+IFS_OLD=$IFS
+trap 'IFS=$IFS_OLD' EXIT SIGINT
+IFS=$'\n'
+
+current_sha=$(git branch --show-current)
+res=$?
+if [[ $res -gt 0 ]]; then
+  current_sha=$(git rev-parse --short HEAD)
+fi;
+# clean up handler. This warns, but does help escape the loop on interrupt
+trap "git checkout $current_sha; exit 1" EXIT SIGINT
+
+inventory=$(cat inventory.txt)
+for line in ${inventory}; do
+  echo $line;
+  tarball=$(echo $line | cut -d: -f 1);
+  gitsha=$(echo $line | cut -d' ' -f 2);
+  cversion=${tarball/couchdb-/};
+  cversion=${cversion/.tgz/};
+  echo "--> Checking out '$gitsha' for chart version '$cversion'";
+
+  git checkout $gitsha;
+
+  long_sha=$(git rev-parse $gitsha)
+
+  read -n 1 -p "Pausing to check if this is ok. Press any key to continue: ";
+  echo ;
+  echo "--> Continuing...";
+  echo; echo;
+
+  if [[ "$execute" == "execute" ]] && [[ -n "$token" ]]; then
+    echo "--> Setting tag for release ${cversion} and sha ${gitsha}!"
+    git tag -f ${chart_name}-${cversion}
+    echo "--> Executing release!"
+    ./bin/cr package ../couchdb
+    ./bin/cr upload -c "$long_sha" --skip-existing -t "$token" -o $owner -r $repo
+    git push --tags --force
+    # clean the directory
+    rm .cr-release-packages/*
+  else
+    echo "--> 'execute' was not provided to the .sh invocation. Skipping..."
+  fi
+
+done
+
+git checkout $current_sha
+exit 0


### PR DESCRIPTION
#### What this PR does / why we need it:

Create the scripts and tooling to support creating GitHub releases with the appropriate chart data, as discussed in #62 . I tested this on my fork (you can see the releases there). It does nothing on its own, and does not help create the index.yaml or the repo proper. However, it does enable creating the backfill of GitHub Releases to build an index.yaml with later.

This branch is not very appropriately named. I will follow up with a PR that adds the CI elements to maintain this going forwards. This PR is only for backfill and should not change state for #62.

Everything it does should be reversible (i.e. deleting releases in the GitHub UI), although to delete tags, you have to [do a bit on the command line](https://www.abeautifulsite.net/posts/how-to-delete-a-tag-on-github/)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:


#### Checklist

(removed because this does not change chart data)
