### PR TITLE
Add CI via GitHub Actions

### DIFF
--- a/.github/workflows/chart-rebuild.yaml
+++ b/.github/workflows/chart-rebuild.yaml
@@ -1,0 +1,57 @@
+name: Rebuild index.yaml manually
+on:
+  workflow_dispatch:
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 'gh-pages'
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.3
+
+      - name: Rebuild index.yaml
+        env:
+          version: v1.4.0
+        run: |
+          if [[ ! -d "$RUNNER_TOOL_CACHE" ]]; then
+              echo "Cache directory '$RUNNER_TOOL_CACHE' does not exist" >&2
+              exit 1
+          fi
+
+          arch=$(uname -m)
+          cache_dir="$RUNNER_TOOL_CACHE/ct/$version/$arch"
+
+          if [[ ! -d "$cache_dir" ]]; then
+              mkdir -p "$cache_dir"
+
+              echo "Installing chart-releaser..."
+              curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/$version/chart-releaser_${version#v}_linux_amd64.tar.gz"
+              tar -xzf cr.tar.gz -C "$cache_dir"
+              rm -f cr.tar.gz
+
+              echo 'Adding cr directory to PATH...'
+              export PATH="$cache_dir:$PATH"
+          fi
+
+          echo "Rebuilding index.yaml"
+          scripts/rebuild.sh
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Rebuild index.yaml
+          title: Rebuild index.yaml
+
+      - name: Check outputs
+        run: |
+          echo "Created Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -1,0 +1,33 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: .
+          charts_repo_url: https://apache.github.io/couchdb-helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -26,15 +26,17 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch main --chart-dirs .
+          changed=$(ct list-changed --target-branch main --chart-dirs .)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint changed)
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: ct lint --target-branch main --chart-dirs .
 
       - name: Run chart-testing (lint all)
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: ct lint --target-branch main --all --chart-dirs .
 
   install:
@@ -56,7 +58,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch main --chart-dirs .
+          changed=$(ct list-changed --target-branch main --chart-dirs .)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
@@ -68,11 +70,11 @@ jobs:
       # no allow-failure until https://github.com/actions/toolkit/issues/399
       - name: Run chart-testing (install changed)
         if: ${{ github.ref != 'refs/heads/main' }}
-        run: ct install --target-branch main --chart-dirs .
+        run: ct install --target-branch main --chart-dirs --upgrade .
         continue-on-error: true
 
       # no allow-failure until https://github.com/actions/toolkit/issues/399
       - name: Run chart-testing (install all)
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: ct install --target-branch main --all --chart-dirs .
+        run: ct install --target-branch main --all --chart-dirs --upgrade .
         continue-on-error: true

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -1,0 +1,78 @@
+name: Lint and Test Charts
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.3
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch main --chart-dirs .
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint changed)
+        run: ct lint --target-branch main --chart-dirs .
+
+      - name: Run chart-testing (lint all)
+        run: ct lint --target-branch main --all --chart-dirs .
+
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.3
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch main --chart-dirs .
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: ( steps.list-changed.outputs.changed == 'true' ) || ${{ github.ref == 'refs/heads/main' }}
+
+      # no allow-failure until https://github.com/actions/toolkit/issues/399
+      - name: Run chart-testing (install changed)
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: ct install --target-branch main --chart-dirs .
+        continue-on-error: true
+
+      # no allow-failure until https://github.com/actions/toolkit/issues/399
+      - name: Run chart-testing (install all)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: ct install --target-branch main --all --chart-dirs .
+        continue-on-error: true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,20 @@
+# Rebuilding Index
+
+The Helm `index.yaml` is hosted on the `gh-pages` branch of this repo. If this
+index becomes out-of-sync with the releases, you can rebuild it by using a
+GitHub Actions Workflow.
+
+## Prerequisites
+
+- To use the `rebuild.sh` script with our workflow, the `rebuild.sh`
+  script must be checked in to the `gh-pages` branch. If you make any changes
+  to the script in this directory, make sure you also commit the same changes
+  to the `gh-pages` branch.
+- You must have permission to run GitHub Actions Workflows for this repo.
+
+## Running the Action
+
+- Navigate to the GitHub Actions UI.
+- Use the `Run Workflow` button to run the workflow.
+- Review the Pull Request created by the workflow.
+- When approved, merge the Pull Request into the `gh-pages` branch.

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Run this script from the root of the helm repo, e.g.,
+# ./scripts/rebuild.sh. You must have curl and cr installed. See
+# https://github.com/helm/chart-releaser#installation.
+
+# Set this to a valid URL *without* an index.yaml if you want to regenerate
+# a new index.html. If you want to append to an existing one, you can
+# use a real address like `https://apache.github.io/couchdb-helm`. If an existing
+# index.yaml is found at this URL, then any packages we generate will
+# be appended, which can result in duplicates.
+HELM_REPO=${HELM_REPO:-https://apache.github.io}
+
+# Create a temporary directory and clean it up when we're done.
+TMP_DIR=$(mktemp -d)
+function cleanup()
+{
+    echo "Removing temporary directory ${TMP_DIR}."
+    rm -rf $TMP_DIR
+}
+trap cleanup EXIT
+
+# Optional variables you can define in your env
+PACKAGE_DIR=${PACKAGE_DIR:-${TMP_DIR}}
+CHARTS_DIR=${CHARTS_DIR:-charts}
+INDEX=${INDEX:-index.yaml}
+GITHUB_OWNER=${GITHUB_OWNER:-apache}
+GITHUB_REPO=${GITHUB_REPO:-couchdb-helm}
+
+# Calculated variables
+DOWNLOADS_BASE="https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download"
+
+# List all tags oldest to newest, followed by the 'main' branch.
+tags="$(git tag -l  --sort=creatordate) main"
+
+# Clean the packages release directory that `cr` uses.
+mkdir -p ${PACKAGE_DIR}
+rm -rf ${PACKAGE_DIR}/*
+
+# Download existing assets from Github
+for tag in $tags; do
+  dl_url="${DOWNLOADS_BASE}/${tag}/${tag}.tgz"
+  cd ${PACKAGE_DIR}
+  curl -LOs --fail ${dl_url}
+  result=$?
+  if [[ ${result} -eq 0 ]]; then
+    echo "Downloaded $dl_url".
+  else
+    echo "Could not download $dl_url".
+  fi
+  cd -
+done
+
+echo "Writing index to ${INDEX}"
+rm ${INDEX}
+cr index --owner ${GITHUB_OWNER} --git-repo ${GITHUB_REPO} --charts-repo ${HELM_REPO} -p ${PACKAGE_DIR} -i ${INDEX}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add CI:
- lint/test
    - lint changed charts
    - then lint all charts
    - run kind
    (these are allowed to fail)
    - install changed charts
    - install all charts
- release (on main, see if any new chart versions - if so, GitHub release and update the index.yaml on the `gh-pages` branch)
- rebuild (rebuilds the index.yaml file from GitHub release history)

Some open items to discuss here:
- how do we do this in such a way that it does not affect your current setup? Should we create a `gh-pages` branch to maintain the "new" index.yaml on until you want to cut over the definition of GitHub pages? Will that affect anything?
- should we remove the "changed vs. all" components of the action? It is most useful when there is more than one chart in a repo. Which side should we err on? Only run lint/test when there are changes? Always run them (even on docs PRs?)
- are any of the dependencies concerning? Of note:
    - azure/setup-helm
    - actions/checkout
    - peter-evans/create-pull-request
    - helm/chart-releaser-action, helm/chart-testing-action, helm/kind-action
- we also have an action that we use to code-generate `README.md` (to keep documentation up to date with the `values.yaml` file) via [`helm-docs`](https://github.com/norwoodj/helm-docs). Is this something that would be interesting to you?
- are there any arguments to linting and testing that would be helpful? i.e. `--upgrade` maybe? The goal of separating here was to allow preventing installation if lint fails
https://github.com/apache/couchdb-helm/blob/bd9bce1a54cebd85448ff620e79ed0f64d18a7b4/test/e2e-kind.sh#L64

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #62

#### Special notes for your reviewer:

#### Checklist

(removed: NA)
