### PR TITLE
Add helm-docs

### DIFF
--- a/_templates.gotmpl
+++ b/_templates.gotmpl
@@ -1,0 +1,9 @@
+{{- define "couchdb.valuesTable" }}
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+  {{- range .Values }}
+      {{- if eq .Key "allowAdminParty" "clusterSize" "couchdbConfig" "createAdminSecret" "schedulerName" "erlangFlags" "persistentVolume" "enableSearch" }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,5 +1,7 @@
 # CouchDB
 
+![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
 reliability.
@@ -16,6 +18,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
+  --version=3.6.1 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -41,6 +44,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
+  --version=3.6.1 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -59,14 +63,14 @@ Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
 $  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
 ```
 
-If you want to set the `adminHash` directly to achieve consistent salts between 
+If you want to set the `adminHash` directly to achieve consistent salts between
 different nodes you need to addionally add the key `password.ini` to the secret:
 
 ```bash
 $  kubectl create secret generic my-release-couchdb \
    --from-literal=adminUsername=foo \
    --from-literal=cookieAuthSecret=baz \
-   --from-file=./my-password.ini 
+   --from-file=./my-password.ini
 ```
 
 With the following contents in `my-password.ini`:
@@ -81,6 +85,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
+  --version=3.6.1 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -116,6 +121,7 @@ upgrade as follows:
 
 ```bash
 $ helm upgrade <release-name> \
+  --version=3.6.1 \
   --reuse-values \
   --set couchdbConfig.couchdb.uuid=<UUID> \
   couchdb/couchdb
@@ -128,7 +134,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release couchdb/couchdb
+$ helm upgrade my-release --version=3.6.1 couchdb/couchdb
 ```
 
 ## Configuration
@@ -136,17 +142,15 @@ $ helm upgrade my-release couchdb/couchdb
 The following table lists the most commonly configured parameters of the
 CouchDB chart and their default values:
 
-|           Parameter             |             Description                               |                Default                 |
-|---------------------------------|-------------------------------------------------------|----------------------------------------|
-| `clusterSize`                   | The initial number of nodes in the CouchDB cluster    | 3                                      |
-| `couchdbConfig`                 | Map allowing override elements of server .ini config  | *See below*                            |
-| `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
-| `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
-| `schedulerName`                 | Name of the k8s scheduler (other than default)        | `nil`                                  |
-| `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster
-| `persistentVolume.enabled`      | Boolean determining whether to attach a PV to each node | false
-| `persistentVolume.size`         | If enabled, the size of the persistent volume to attach                          | 10Gi
-| `enableSearch`                  | Adds a sidecar for Lucene-powered text search         | false                                  |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| allowAdminParty | bool | `false` | If allowAdminParty is enabled the cluster will start up without any database administrator account; i.e., all users will be granted administrative access. Otherwise, the system will look for a Secret called <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys. See the `createAdminSecret` flag. ref: https://kubernetes.io/docs/concepts/configuration/secret/ |
+| clusterSize | int | `3` | the initial number of nodes in the CouchDB cluster. |
+| couchdbConfig | object | `{"chttpd":{"bind_address":"any","require_valid_user":false}}` | couchdbConfig will override default CouchDB configuration settings. The contents of this map are reformatted into a .ini file laid down by a ConfigMap object. ref: http://docs.couchdb.org/en/latest/config/index.html |
+| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options: 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace. 2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
+| enableSearch | bool | `false` | Flip this to flag to include the Search container in each Pod |
+| erlangFlags | object | `{"name":"couchdb"}` | erlangFlags is a map that is passed to the Erlang VM as flags using the ERL_FLAGS env. The `name` flag is required to establish connectivity between cluster nodes. ref: http://erlang.org/doc/man/erl.html#init_flags |
+| persistentVolume | object | `{"accessModes":["ReadWriteOnce"],"enabled":false,"size":"10Gi"}` | The storage volume used by each Pod in the StatefulSet. If a persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral local storage. Setting the storageClass attribute to "-" disables dynamic provisioning of Persistent Volumes; leaving it unset will invoke the default provisioner. |
 
 You can set the values of the `couchdbConfig` map according to the
 [official configuration][4]. The following shows the map's default values and

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -1,0 +1,247 @@
+# CouchDB
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+Apache CouchDB is a database featuring seamless multi-master sync, that scales
+from big data to mobile, with an intuitive HTTP/JSON API and designed for
+reliability.
+
+This chart deploys a CouchDB cluster as a StatefulSet. It creates a ClusterIP
+Service in front of the Deployment for load balancing by default, but can also
+be configured to deploy other Service types or an Ingress Controller. The
+default persistence mechanism is simply the ephemeral local filesystem, but
+production deployments should set `persistentVolume.enabled` to `true` to attach
+storage volumes to each Pod in the Deployment.
+
+## TL;DR
+
+```bash
+$ helm repo add couchdb https://apache.github.io/couchdb-helm
+$ helm install couchdb/couchdb \
+  --version={{ template "chart.version" . }} \
+  --set allowAdminParty=true \
+  --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
+```
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+- Ingress requires Kubernetes 1.19+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+Add the CouchDB Helm repository:
+
+```bash
+$ helm repo add couchdb https://apache.github.io/couchdb-helm
+```
+
+Afterwards install the chart replacing the UUID
+`decafbaddecafbaddecafbaddecafbad` with a custom one:
+
+```bash
+$ helm install \
+  --name my-release \
+  --version={{ template "chart.version" . }} \
+  --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
+  couchdb/couchdb
+```
+
+This will create a Secret containing the admin credentials for the cluster.
+Those credentials can be retrieved as follows:
+
+```bash
+$ kubectl get secret my-release-couchdb -o go-template='{{ print "{{ .data.adminPassword }}" }}' | base64 --decode
+```
+
+If you prefer to configure the admin credentials directly you can create a
+Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
+
+```bash
+$  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
+```
+
+If you want to set the `adminHash` directly to achieve consistent salts between 
+different nodes you need to addionally add the key `password.ini` to the secret:
+
+```bash
+$  kubectl create secret generic my-release-couchdb \
+   --from-literal=adminUsername=foo \
+   --from-literal=cookieAuthSecret=baz \
+   --from-file=./my-password.ini 
+```
+
+With the following contents in `my-password.ini`:
+
+```
+[admins]
+foo = <pbkdf2-hash>
+```
+
+and then install the chart while overriding the `createAdminSecret` setting:
+
+```bash
+$ helm install \
+  --name my-release \
+  --version={{ template "chart.version" . }} \
+  --set createAdminSecret=false \
+  --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
+  couchdb/couchdb
+```
+
+This Helm chart deploys CouchDB on the Kubernetes cluster in a default
+configuration. The [configuration](#configuration) section lists
+the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` Deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v0.2.3 -> v1.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### Upgrade to 3.0.0
+
+Since version 3.0.0 setting the CouchDB server instance UUID is mandatory.
+Therefore you need to generate a UUID and supply it as a value during the
+upgrade as follows:
+
+```bash
+$ helm upgrade <release-name> \
+  --version={{ template "chart.version" . }} \
+  --reuse-values \
+  --set couchdbConfig.couchdb.uuid=<UUID> \
+  couchdb/couchdb
+```
+
+## Migrating from stable/couchdb
+
+This chart replaces the `stable/couchdb` chart previously hosted by Helm and continues the
+version semantics. You can upgrade directly from `stable/couchdb` to this chart using:
+
+```bash
+$ helm repo add couchdb https://apache.github.io/couchdb-helm
+$ helm upgrade my-release --version={{ template "chart.version" . }} couchdb/couchdb
+```
+
+## Configuration
+
+The following table lists the most commonly configured parameters of the
+CouchDB chart and their default values:
+
+{{ template "couchdb.valuesTable" . }}
+
+You can set the values of the `couchdbConfig` map according to the
+[official configuration][4]. The following shows the map's default values and
+required options to set:
+
+|           Parameter             |             Description                                            |                Default                 |
+|---------------------------------|--------------------------------------------------------------------|----------------------------------------|
+| `couchdb.uuid`                  | UUID for this CouchDB server instance ([Required in a cluster][5]) |                                        |
+| `chttpd.bind_address`           | listens on all interfaces when set to any                          | any                                    |
+| `chttpd.require_valid_user`     | disables all the anonymous requests to the port 5984 when true     | false                                  |
+
+A variety of other parameters are also configurable. See the comments in the
+`values.yaml` file for further details:
+
+|           Parameter                  |                Default                 |
+|--------------------------------------|----------------------------------------|
+| `adminUsername`                      | admin                                  |
+| `adminPassword`                      | auto-generated                         |
+| `adminHash`                          |                                        |
+| `cookieAuthSecret`                   | auto-generated                         |
+| `image.repository`                   | couchdb                                |
+| `image.tag`                          | 3.2.1                                  |
+| `image.pullPolicy`                   | IfNotPresent                           |
+| `searchImage.repository`             | kocolosk/couchdb-search                |
+| `searchImage.tag`                    | 0.1.0                                  |
+| `searchImage.pullPolicy`             | IfNotPresent                           |
+| `initImage.repository`               | busybox                                |
+| `initImage.tag`                      | latest                                 |
+| `initImage.pullPolicy`               | Always                                 |
+| `ingress.enabled`                    | false                                  |
+| `ingress.hosts`                      | chart-example.local                    |
+| `ingress.annotations`                |                                        |
+| `ingress.path`                       | /                                      |
+| `ingress.tls`                        |                                        |
+| `persistentVolume.accessModes`       | ReadWriteOnce                          |
+| `persistentVolume.storageClass`      | Default for the Kube cluster           |
+| `podManagementPolicy`                | Parallel                               |
+| `affinity`                           |                                        |
+| `topologySpreadConstraints`          |                                        |
+| `annotations`                        |                                        |
+| `tolerations`                        |                                        |
+| `resources`                          |                                        |
+| `service.annotations`                |                                        |
+| `service.enabled`                    | true                                   |
+| `service.type`                       | ClusterIP                              |
+| `service.externalPort`               | 5984                                   |
+| `dns.clusterDomainSuffix`            | cluster.local                          |
+| `networkPolicy.enabled`              | true                                   |
+| `serviceAccount.enabled`             | true                                   |
+| `serviceAccount.create`              | true                                   |
+| `serviceAccount.imagePullSecrets`    |                                        |
+| `sidecars`                           | {}                                     |
+| `livenessProbe.enabled`              | true                                   |
+| `livenessProbe.failureThreshold`     | 3                                      |
+| `livenessProbe.initialDelaySeconds`  | 0                                      |
+| `livenessProbe.periodSeconds`        | 10                                     |
+| `livenessProbe.successThreshold`     | 1                                      |
+| `livenessProbe.timeoutSeconds`       | 1                                      |
+| `readinessProbe.enabled`             | true                                   |
+| `readinessProbe.failureThreshold`    | 3                                      |
+| `readinessProbe.initialDelaySeconds` | 0                                      |
+| `readinessProbe.periodSeconds`       | 10                                     |
+| `readinessProbe.successThreshold`    | 1                                      |
+| `readinessProbe.timeoutSeconds`      | 1                                      |
+| `prometheusPort.enabled`             | false                                  |
+| `prometheusPort.port`                | 17896                                  |
+| `prometheusPort.bind_address`        | 0.0.0.0                                |
+| `placementConfig.enabled`            | false                                  |
+| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager|
+| `placementConfig.image.tag`          | 0.1.0                                  |
+
+## Feedback, Issues, Contributing
+
+General feedback is welcome at our [user][1] or [developer][2] mailing lists.
+
+Apache CouchDB has a [CONTRIBUTING][3] file with details on how to get started
+with issue reporting or contributing to the upkeep of this project. In short,
+use GitHub Issues, do not report anything on Docker's website.
+
+## Non-Apache CouchDB Development Team Contributors
+
+- [@natarajaya](https://github.com/natarajaya)
+- [@satchpx](https://github.com/satchpx)
+- [@spanato](https://github.com/spanato)
+- [@jpds](https://github.com/jpds)
+- [@sebastien-prudhomme](https://github.com/sebastien-prudhomme)
+- [@stepanstipl](https://github.com/sebastien-stepanstipl)
+- [@amatas](https://github.com/amatas)
+- [@Chimney42](https://github.com/Chimney42)
+- [@mattjmcnaughton](https://github.com/mattjmcnaughton)
+- [@mainephd](https://github.com/mainephd)
+- [@AdamDang](https://github.com/AdamDang)
+- [@mrtyler](https://github.com/mrtyler)
+- [@kevinwlau](https://github.com/kevinwlau)
+- [@jeyenzo](https://github.com/jeyenzo)
+- [@Pinpin31.](https://github.com/Pinpin31)
+
+[1]: http://mail-archives.apache.org/mod_mbox/couchdb-user/
+[2]: http://mail-archives.apache.org/mod_mbox/couchdb-dev/
+[3]: https://github.com/apache/couchdb/blob/master/CONTRIBUTING.md
+[4]: https://docs.couchdb.org/en/stable/config/index.html
+[5]: https://docs.couchdb.org/en/latest/setup/cluster.html#preparing-couchdb-nodes-to-be-joined-into-a-cluster

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -1,25 +1,25 @@
-## clusterSize is the initial size of the CouchDB cluster.
+# -- the initial number of nodes in the CouchDB cluster.
 clusterSize: 3
 
-## If allowAdminParty is enabled the cluster will start up without any database
-## administrator account; i.e., all users will be granted administrative
-## access. Otherwise, the system will look for a Secret called
-## <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and
-## `cookieAuthSecret` keys. See the `createAdminSecret` flag.
-## ref: https://kubernetes.io/docs/concepts/configuration/secret/
+# -- If allowAdminParty is enabled the cluster will start up without any database
+# administrator account; i.e., all users will be granted administrative
+# access. Otherwise, the system will look for a Secret called
+# <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and
+# `cookieAuthSecret` keys. See the `createAdminSecret` flag.
+# ref: https://kubernetes.io/docs/concepts/configuration/secret/
 allowAdminParty: false
 
-## If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will
-## be created containing auto-generated credentials. Users who prefer to set
-## these values themselves have a couple of options:
-##
-## 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`
-##    can be defined directly in the chart's values. Note that all of a chart's
-##    values are currently stored in plaintext in a ConfigMap in the tiller
-##    namespace.
-##
-## 2) This flag can be disabled and a Secret with the required keys can be
-##    created ahead of time.
+# -- If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will
+# be created containing auto-generated credentials. Users who prefer to set
+# these values themselves have a couple of options:
+#
+# 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`
+#    can be defined directly in the chart's values. Note that all of a chart's
+#    values are currently stored in plaintext in a ConfigMap in the tiller
+#    namespace.
+#
+# 2) This flag can be disabled and a Secret with the required keys can be
+#    created ahead of time.
 createAdminSecret: true
 
 adminUsername: admin
@@ -45,11 +45,11 @@ serviceAccount:
 # imagePullSecrets:
 # - name: myimagepullsecret
 
-## The storage volume used by each Pod in the StatefulSet. If a
-## persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral
-## local storage. Setting the storageClass attribute to "-" disables dynamic
-## provisioning of Persistent Volumes; leaving it unset will invoke the default
-## provisioner.
+# -- The storage volume used by each Pod in the StatefulSet. If a
+# persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral
+# local storage. Setting the storageClass attribute to "-" disables dynamic
+# provisioning of Persistent Volumes; leaving it unset will invoke the default
+# provisioner.
 persistentVolume:
   enabled: false
   accessModes:
@@ -69,7 +69,7 @@ searchImage:
   tag: 0.2.0
   pullPolicy: IfNotPresent
 
-## Flip this to flag to include the Search container in each Pod
+# -- Flip this to flag to include the Search container in each Pod
 enableSearch: false
 
 initImage:
@@ -151,10 +151,10 @@ resources:
   #  cpu: 56
   #  memory: 256Gi
 
-## erlangFlags is a map that is passed to the Erlang VM as flags using the
-## ERL_FLAGS env. The `name` flag is required to establish connectivity
-## between cluster nodes.
-## ref: http://erlang.org/doc/man/erl.html#init_flags
+# -- erlangFlags is a map that is passed to the Erlang VM as flags using the
+# ERL_FLAGS env. The `name` flag is required to establish connectivity
+# between cluster nodes.
+# ref: http://erlang.org/doc/man/erl.html#init_flags
 erlangFlags:
   name: couchdb
   # Older versions of the official CouchDB image (anything prior to 3.2.1)
@@ -162,10 +162,10 @@ erlangFlags:
   # want to cluster these deployments it's necessary to pass in a cookie here
   # setcookie: make-something-up
 
-## couchdbConfig will override default CouchDB configuration settings.
-## The contents of this map are reformatted into a .ini file laid down
-## by a ConfigMap object.
-## ref: http://docs.couchdb.org/en/latest/config/index.html
+# -- couchdbConfig will override default CouchDB configuration settings.
+# The contents of this map are reformatted into a .ini file laid down
+# by a ConfigMap object.
+# ref: http://docs.couchdb.org/en/latest/config/index.html
 couchdbConfig:
   # couchdb:
   #  uuid: decafbaddecafbaddecafbaddecafbad # Unique identifier for this CouchDB server instance


### PR DESCRIPTION
#### What this PR does / why we need it:

This begins replacing the manual README.md generation with auto-generation using `helm-docs` (as discussed in #81 ). This does not finish that issue, because it does not solve the CI problem (yet). This is meant for discussion about `helm-docs` itself and the implementation questions raised in #81 

README as generated on GitHub can be reviewed here: https://github.com/colearendt/couchdb-helm/tree/add-docs/couchdb

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

Will require a chart version bump (changing README), so should not be merged until after #80

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
