### PR TITLE
switch GitHub pages to gh-pages branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -8,5 +8,6 @@ github:
     main:
       required_status_checks:
         strict: true
-  ghp_branch:  main
-  ghp_path:    /docs
+      required_linear_history: true
+    gh-pages: {}
+  ghp_branch: gh-pages


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

This updates `.asf.yaml` to use the [gh-pages](https://github.com/apache/couchdb-helm/tree/gh-pages) branch as the source for GitHub pages (published to `https://apache.github.io/couchdb-helm`). This effectively migrates the Helm repository to that branch which defines a new `index.yaml` referencing the newly created GitHub Release artifacts (see #79).

In addition:
- Require linear history for the `main` branch to ensure PRs are up to date prior to merge.
- Add branch protection to `gh-pages` to prevent force pushes.

The remaining steps to complete migration are:

1. Verify the new gh-pages content/Helm repository.
2. Remove the legacy `/docs` folder.
3. Update the PR template to reflect that manual chart packaging is no longer required.
4. Update `CONTRIBUTORS.md` to relfect the new process for chart publishing.

