### PR TITLE
Auto-generate a stateful erlangCookie

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 3.6.1
+version: 3.6.2
 appVersion: 3.2.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,0 +1,6 @@
+# NEWS
+
+## 3.6.2
+
+- Change the `erlangCookie` to be auto-generated in a stateful fashion (i.e. we auto-generate it once, then leave that
+  value alone). ([#78](https://github.com/apache/couchdb-helm/issues/78))

--- a/couchdb/templates/NOTES.txt
+++ b/couchdb/templates/NOTES.txt
@@ -18,3 +18,15 @@ some required system databases:
 {{- end }}
 
 Then it's time to relax.
+
+{{- $erlangCookie := .Values.erlangFlags.setcookie }}
+{{- if (empty $erlangCookie) }}
+
+NOTE: You are using an auto-generated value for the Erlang Cookie
+  - We recommend making this value persistent by setting it in: `erlangFlags.setcookie`
+  - Changing this value can cause problems for the Couch DB installation (particularly upgrades / config changes)
+  - You can get the current value with:
+```
+kubectl -n {{ $.Release.Namespace }} get secret {{ include "couchdb.fullname" . }} --template='{{print "{{" }}index .data "erlangCookie" | base64decode{{ print "}}" }}'
+```
+{{- end }}

--- a/couchdb/templates/secrets.yaml
+++ b/couchdb/templates/secrets.yaml
@@ -12,7 +12,8 @@ type: Opaque
 data:
   adminUsername: {{ template "couchdb.defaultsecret" .Values.adminUsername }}
   adminPassword: {{ template "couchdb.defaultsecret" .Values.adminPassword }}
-  erlangCookie: {{ template "couchdb.defaultsecret" .Values.erlangFlags.setcookie }}
+  {{- $erlangCookieArgs := dict "key" "erlangCookie" "ns" $.Release.Namespace "secretName" (include "couchdb.fullname" .) "secret" .Values.erlangFlags.setcookie }}
+  erlangCookie: {{ template "couchdb.defaultsecret-stateful" $erlangCookieArgs }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
 {{- if  .Values.adminHash  }}
   password.ini: {{ tpl (.Files.Get "password.ini") . | b64enc }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Discussed in #78

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #78
  - fixes #88 

#### Special notes for your reviewer:

- Need to make sure that NOTES.txt and the new "stateful" secret generation does not error on various types of inputs (I intend to do more testing here)
- Some design choices could be evaluated. For instance:
    - Simplify the input by passing the global context (so `Namespace` can be determined) and hard-coding the secret name
    - Whether or not to use `NOTES.txt` the way we have, or whether a generic message would be more helpful (i.e. is it too verbose? Should it be in a different location?)
    - Whether `NEWS.md` seems like a helpful convention
    - Whether we should be using `index` to protect against missing keys like I did in #73 
    - Whether this is a desirable approach or `erlangCookie` should be refactored more heavily

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] Chart tgz added to /docs and index updated
