### PR TITLE
Simplify secrets to avoid dependencies on a file and keep only the se…

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 3.6.3
+version: 3.7.0
 appVersion: 3.2.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,10 @@
 # NEWS
 
+## 3.7.0
+
+- Simplified the `adminHash` in the secret
+- Added the `autoSetup` to automatically finalize the cluster after installation
+
 ## 3.6.2
 
 - Change the `erlangCookie` to be auto-generated in a stateful fashion (i.e. we auto-generate it once, then leave that

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -5,6 +5,18 @@
 - Simplified the `adminHash` in the secret
 - Added the `autoSetup` to automatically finalize the cluster after installation
 
+# 3.6.4
+
+- Add `service.labels` value to pass along labels to the client-facing service
+- Update `ingress` to use the service created by `service.enabled=true`,
+  instead of the headless service
+  ([#94](https://github.com/apache/couchdb-helm/issues/94))
+  - This allows setting `service.annotations`, `service.labels`, etc. in a way that will be picked up by the ingress
+
+# 3.6.3
+
+- Add PersistentVolume annotations
+
 ## 3.6.2
 
 - Change the `erlangCookie` to be auto-generated in a stateful fashion (i.e. we auto-generate it once, then leave that

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -64,20 +64,13 @@ $  kubectl create secret generic my-release-couchdb --from-literal=adminUsername
 ```
 
 If you want to set the `adminHash` directly to achieve consistent salts between
-different nodes you need to addionally add the key `password.ini` to the secret:
+different nodes you need to add it to the secret:
 
 ```bash
 $  kubectl create secret generic my-release-couchdb \
    --from-literal=adminUsername=foo \
    --from-literal=cookieAuthSecret=baz \
-   --from-file=./my-password.ini
-```
-
-With the following contents in `my-password.ini`:
-
-```
-[admins]
-foo = <pbkdf2-hash>
+   --from-literal=adminHash=-pbkdf2-d4b887da....
 ```
 
 and then install the chart while overriding the `createAdminSecret` setting:
@@ -86,6 +79,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 $ helm install \
   --name my-release \
   --version=3.6.1 \
+  --set adminHash=true/false \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -116,7 +110,7 @@ incompatible breaking change needing manual actions.
 ### Upgrade to 3.0.0
 
 Since version 3.0.0 setting the CouchDB server instance UUID is mandatory.
-Therefore you need to generate a UUID and supply it as a value during the
+Therefore, you need to generate a UUID and supply it as a value during the
 upgrade as follows:
 
 ```bash
@@ -165,63 +159,68 @@ required options to set:
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
-|           Parameter                  |                Default                 |
-|--------------------------------------|----------------------------------------|
-| `adminUsername`                      | admin                                  |
-| `adminPassword`                      | auto-generated                         |
-| `adminHash`                          |                                        |
-| `cookieAuthSecret`                   | auto-generated                         |
-| `image.repository`                   | couchdb                                |
-| `image.tag`                          | 3.2.1                                  |
-| `image.pullPolicy`                   | IfNotPresent                           |
-| `searchImage.repository`             | kocolosk/couchdb-search                |
-| `searchImage.tag`                    | 0.1.0                                  |
-| `searchImage.pullPolicy`             | IfNotPresent                           |
-| `initImage.repository`               | busybox                                |
-| `initImage.tag`                      | latest                                 |
-| `initImage.pullPolicy`               | Always                                 |
-| `ingress.enabled`                    | false                                  |
-| `ingress.hosts`                      | chart-example.local                    |
-| `ingress.annotations`                |                                        |
-| `ingress.path`                       | /                                      |
-| `ingress.tls`                        |                                        |
-| `persistentVolume.accessModes`       | ReadWriteOnce                          |
-| `persistentVolume.storageClass`      | Default for the Kube cluster           |
-| `persistentVolume.annotations`       | {}                                     |
-| `podManagementPolicy`                | Parallel                               |
-| `affinity`                           |                                        |
-| `topologySpreadConstraints`          |                                        |
-| `annotations`                        |                                        |
-| `tolerations`                        |                                        |
-| `resources`                          |                                        |
-| `service.annotations`                |                                        |
-| `service.enabled`                    | true                                   |
-| `service.type`                       | ClusterIP                              |
-| `service.externalPort`               | 5984                                   |
-| `dns.clusterDomainSuffix`            | cluster.local                          |
-| `networkPolicy.enabled`              | true                                   |
-| `serviceAccount.enabled`             | true                                   |
-| `serviceAccount.create`              | true                                   |
-| `serviceAccount.imagePullSecrets`    |                                        |
-| `sidecars`                           | {}                                     |
-| `livenessProbe.enabled`              | true                                   |
-| `livenessProbe.failureThreshold`     | 3                                      |
-| `livenessProbe.initialDelaySeconds`  | 0                                      |
-| `livenessProbe.periodSeconds`        | 10                                     |
-| `livenessProbe.successThreshold`     | 1                                      |
-| `livenessProbe.timeoutSeconds`       | 1                                      |
-| `readinessProbe.enabled`             | true                                   |
-| `readinessProbe.failureThreshold`    | 3                                      |
-| `readinessProbe.initialDelaySeconds` | 0                                      |
-| `readinessProbe.periodSeconds`       | 10                                     |
-| `readinessProbe.successThreshold`    | 1                                      |
-| `readinessProbe.timeoutSeconds`      | 1                                      |
-| `prometheusPort.enabled`             | false                                  |
-| `prometheusPort.port`                | 17896                                  |
-| `prometheusPort.bind_address`        | 0.0.0.0                                |
-| `placementConfig.enabled`            | false                                  |
-| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager|
-| `placementConfig.image.tag`          | 0.1.0                                  |
+| Parameter                            | Default                                                                                                                                                      |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `adminUsername`                      | admin                                                                                                                                                        |
+| `adminPassword`                      | auto-generated                                                                                                                                               |
+| `adminHash`                          |                                                                                                                                                              |
+| `cookieAuthSecret`                   | auto-generated                                                                                                                                               |
+| `image.repository`                   | couchdb                                                                                                                                                      |
+| `image.tag`                          | 3.2.1                                                                                                                                                        |
+| `image.pullPolicy`                   | IfNotPresent                                                                                                                                                 |
+| `searchImage.repository`             | kocolosk/couchdb-search                                                                                                                                      |
+| `searchImage.tag`                    | 0.1.0                                                                                                                                                        |
+| `searchImage.pullPolicy`             | IfNotPresent                                                                                                                                                 |
+| `initImage.repository`               | busybox                                                                                                                                                      |
+| `initImage.tag`                      | latest                                                                                                                                                       |
+| `initImage.pullPolicy`               | Always                                                                                                                                                       |
+| `ingress.enabled`                    | false                                                                                                                                                        |
+| `ingress.hosts`                      | chart-example.local                                                                                                                                          |
+| `ingress.annotations`                |                                                                                                                                                              |
+| `ingress.path`                       | /                                                                                                                                                            |
+| `ingress.tls`                        |                                                                                                                                                              |
+| `persistentVolume.accessModes`       | ReadWriteOnce                                                                                                                                                |
+| `persistentVolume.storageClass`      | Default for the Kube cluster                                                                                                                                 |
+| `persistentVolume.annotations`       | {}                                                                                                                                                           |
+| `podManagementPolicy`                | Parallel                                                                                                                                                     |
+| `affinity`                           |                                                                                                                                                              |
+| `topologySpreadConstraints`          |                                                                                                                                                              |
+| `annotations`                        |                                                                                                                                                              |
+| `tolerations`                        |                                                                                                                                                              |
+| `resources`                          |                                                                                                                                                              |
+| `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure) |
+| `autoSetup.repository`               | alpine/curl                                                                                                                                                  |
+| `autoSetup.tag`                      | latest                                                                                                                                                       |
+| `autoSetup.pullPolicy`               | Always                                                                                                                                                       |
+| `autoSetup.defaultDatabases`         | [`_global_changes`]                                                                                                                                          |
+| `service.annotations`                |                                                                                                                                                              |
+| `service.enabled`                    | true                                                                                                                                                         |
+| `service.type`                       | ClusterIP                                                                                                                                                    |
+| `service.externalPort`               | 5984                                                                                                                                                         |
+| `dns.clusterDomainSuffix`            | cluster.local                                                                                                                                                |
+| `networkPolicy.enabled`              | true                                                                                                                                                         |
+| `serviceAccount.enabled`             | true                                                                                                                                                         |
+| `serviceAccount.create`              | true                                                                                                                                                         |
+| `serviceAccount.imagePullSecrets`    |                                                                                                                                                              |
+| `sidecars`                           | {}                                                                                                                                                           |
+| `livenessProbe.enabled`              | true                                                                                                                                                         |
+| `livenessProbe.failureThreshold`     | 3                                                                                                                                                            |
+| `livenessProbe.initialDelaySeconds`  | 0                                                                                                                                                            |
+| `livenessProbe.periodSeconds`        | 10                                                                                                                                                           |
+| `livenessProbe.successThreshold`     | 1                                                                                                                                                            |
+| `livenessProbe.timeoutSeconds`       | 1                                                                                                                                                            |
+| `readinessProbe.enabled`             | true                                                                                                                                                         |
+| `readinessProbe.failureThreshold`    | 3                                                                                                                                                            |
+| `readinessProbe.initialDelaySeconds` | 0                                                                                                                                                            |
+| `readinessProbe.periodSeconds`       | 10                                                                                                                                                           |
+| `readinessProbe.successThreshold`    | 1                                                                                                                                                            |
+| `readinessProbe.timeoutSeconds`      | 1                                                                                                                                                            |
+| `prometheusPort.enabled`             | false                                                                                                                                                        |
+| `prometheusPort.port`                | 17896                                                                                                                                                        |
+| `prometheusPort.bind_address`        | 0.0.0.0                                                                                                                                                      |
+| `placementConfig.enabled`            | false                                                                                                                                                        |
+| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager                                                                                                              |
+| `placementConfig.image.tag`          | 0.1.0                                                                                                                                                        |
 
 ## Feedback, Issues, Contributing
 

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -63,21 +63,14 @@ Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
 $  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
 ```
 
-If you want to set the `adminHash` directly to achieve consistent salts between 
-different nodes you need to addionally add the key `password.ini` to the secret:
+If you want to set the `adminHash` directly to achieve consistent salts between
+different nodes you need to add it to the secret:
 
 ```bash
 $  kubectl create secret generic my-release-couchdb \
    --from-literal=adminUsername=foo \
    --from-literal=cookieAuthSecret=baz \
-   --from-file=./my-password.ini 
-```
-
-With the following contents in `my-password.ini`:
-
-```
-[admins]
-foo = <pbkdf2-hash>
+   --from-literal=adminHash=-pbkdf2-d4b887da....
 ```
 
 and then install the chart while overriding the `createAdminSecret` setting:
@@ -86,6 +79,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 $ helm install \
   --name my-release \
   --version={{ template "chart.version" . }} \
+  --set adminHash=true/false \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -157,62 +151,68 @@ required options to set:
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
-|           Parameter                  |                Default                 |
-|--------------------------------------|----------------------------------------|
-| `adminUsername`                      | admin                                  |
-| `adminPassword`                      | auto-generated                         |
-| `adminHash`                          |                                        |
-| `cookieAuthSecret`                   | auto-generated                         |
-| `image.repository`                   | couchdb                                |
-| `image.tag`                          | 3.2.1                                  |
-| `image.pullPolicy`                   | IfNotPresent                           |
-| `searchImage.repository`             | kocolosk/couchdb-search                |
-| `searchImage.tag`                    | 0.1.0                                  |
-| `searchImage.pullPolicy`             | IfNotPresent                           |
-| `initImage.repository`               | busybox                                |
-| `initImage.tag`                      | latest                                 |
-| `initImage.pullPolicy`               | Always                                 |
-| `ingress.enabled`                    | false                                  |
-| `ingress.hosts`                      | chart-example.local                    |
-| `ingress.annotations`                |                                        |
-| `ingress.path`                       | /                                      |
-| `ingress.tls`                        |                                        |
-| `persistentVolume.accessModes`       | ReadWriteOnce                          |
-| `persistentVolume.storageClass`      | Default for the Kube cluster           |
-| `podManagementPolicy`                | Parallel                               |
-| `affinity`                           |                                        |
-| `topologySpreadConstraints`          |                                        |
-| `annotations`                        |                                        |
-| `tolerations`                        |                                        |
-| `resources`                          |                                        |
-| `service.annotations`                |                                        |
-| `service.enabled`                    | true                                   |
-| `service.type`                       | ClusterIP                              |
-| `service.externalPort`               | 5984                                   |
-| `dns.clusterDomainSuffix`            | cluster.local                          |
-| `networkPolicy.enabled`              | true                                   |
-| `serviceAccount.enabled`             | true                                   |
-| `serviceAccount.create`              | true                                   |
-| `serviceAccount.imagePullSecrets`    |                                        |
-| `sidecars`                           | {}                                     |
-| `livenessProbe.enabled`              | true                                   |
-| `livenessProbe.failureThreshold`     | 3                                      |
-| `livenessProbe.initialDelaySeconds`  | 0                                      |
-| `livenessProbe.periodSeconds`        | 10                                     |
-| `livenessProbe.successThreshold`     | 1                                      |
-| `livenessProbe.timeoutSeconds`       | 1                                      |
-| `readinessProbe.enabled`             | true                                   |
-| `readinessProbe.failureThreshold`    | 3                                      |
-| `readinessProbe.initialDelaySeconds` | 0                                      |
-| `readinessProbe.periodSeconds`       | 10                                     |
-| `readinessProbe.successThreshold`    | 1                                      |
-| `readinessProbe.timeoutSeconds`      | 1                                      |
-| `prometheusPort.enabled`             | false                                  |
-| `prometheusPort.port`                | 17896                                  |
-| `prometheusPort.bind_address`        | 0.0.0.0                                |
-| `placementConfig.enabled`            | false                                  |
-| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager|
-| `placementConfig.image.tag`          | 0.1.0                                  |
+| Parameter                            | Default                                                                                                                                                      |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `adminUsername`                      | admin                                                                                                                                                        |
+| `adminPassword`                      | auto-generated                                                                                                                                               |
+| `adminHash`                          |                                                                                                                                                              |
+| `cookieAuthSecret`                   | auto-generated                                                                                                                                               |
+| `image.repository`                   | couchdb                                                                                                                                                      |
+| `image.tag`                          | 3.2.1                                                                                                                                                        |
+| `image.pullPolicy`                   | IfNotPresent                                                                                                                                                 |
+| `searchImage.repository`             | kocolosk/couchdb-search                                                                                                                                      |
+| `searchImage.tag`                    | 0.1.0                                                                                                                                                        |
+| `searchImage.pullPolicy`             | IfNotPresent                                                                                                                                                 |
+| `initImage.repository`               | busybox                                                                                                                                                      |
+| `initImage.tag`                      | latest                                                                                                                                                       |
+| `initImage.pullPolicy`               | Always                                                                                                                                                       |
+| `ingress.enabled`                    | false                                                                                                                                                        |
+| `ingress.hosts`                      | chart-example.local                                                                                                                                          |
+| `ingress.annotations`                |                                                                                                                                                              |
+| `ingress.path`                       | /                                                                                                                                                            |
+| `ingress.tls`                        |                                                                                                                                                              |
+| `persistentVolume.accessModes`       | ReadWriteOnce                                                                                                                                                |
+| `persistentVolume.storageClass`      | Default for the Kube cluster                                                                                                                                 |
+| `persistentVolume.annotations`       | {}                                                                                                                                                           |
+| `podManagementPolicy`                | Parallel                                                                                                                                                     |
+| `affinity`                           |                                                                                                                                                              |
+| `topologySpreadConstraints`          |                                                                                                                                                              |
+| `annotations`                        |                                                                                                                                                              |
+| `tolerations`                        |                                                                                                                                                              |
+| `resources`                          |                                                                                                                                                              |
+| `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure) |
+| `autoSetup.repository`               | alpine/curl                                                                                                                                                  |
+| `autoSetup.tag`                      | latest                                                                                                                                                       |
+| `autoSetup.pullPolicy`               | Always                                                                                                                                                       |
+| `autoSetup.defaultDatabases`         | [`_global_changes`]                                                                                                                                          |
+| `service.annotations`                |                                                                                                                                                              |
+| `service.enabled`                    | true                                                                                                                                                         |
+| `service.type`                       | ClusterIP                                                                                                                                                    |
+| `service.externalPort`               | 5984                                                                                                                                                         |
+| `dns.clusterDomainSuffix`            | cluster.local                                                                                                                                                |
+| `networkPolicy.enabled`              | true                                                                                                                                                         |
+| `serviceAccount.enabled`             | true                                                                                                                                                         |
+| `serviceAccount.create`              | true                                                                                                                                                         |
+| `serviceAccount.imagePullSecrets`    |                                                                                                                                                              |
+| `sidecars`                           | {}                                                                                                                                                           |
+| `livenessProbe.enabled`              | true                                                                                                                                                         |
+| `livenessProbe.failureThreshold`     | 3                                                                                                                                                            |
+| `livenessProbe.initialDelaySeconds`  | 0                                                                                                                                                            |
+| `livenessProbe.periodSeconds`        | 10                                                                                                                                                           |
+| `livenessProbe.successThreshold`     | 1                                                                                                                                                            |
+| `livenessProbe.timeoutSeconds`       | 1                                                                                                                                                            |
+| `readinessProbe.enabled`             | true                                                                                                                                                         |
+| `readinessProbe.failureThreshold`    | 3                                                                                                                                                            |
+| `readinessProbe.initialDelaySeconds` | 0                                                                                                                                                            |
+| `readinessProbe.periodSeconds`       | 10                                                                                                                                                           |
+| `readinessProbe.successThreshold`    | 1                                                                                                                                                            |
+| `readinessProbe.timeoutSeconds`      | 1                                                                                                                                                            |
+| `prometheusPort.enabled`             | false                                                                                                                                                        |
+| `prometheusPort.port`                | 17896                                                                                                                                                        |
+| `prometheusPort.bind_address`        | 0.0.0.0                                                                                                                                                      |
+| `placementConfig.enabled`            | false                                                                                                                                                        |
+| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager                                                                                                              |
+| `placementConfig.image.tag`          | 0.1.0                                                                                                                                                        |
 
 ## Feedback, Issues, Contributing
 

--- a/couchdb/password.ini
+++ b/couchdb/password.ini
@@ -1,2 +1,0 @@
-[admins]
-{{ .Values.adminUsername }} = {{ .Values.adminHash }}

--- a/couchdb/templates/job.yaml
+++ b/couchdb/templates/job.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.autoSetup.enabled .Values.service.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-post-install"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-install
+{{/*    "helm.sh/hook-delete-policy": hook-succeeded*/}}
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-post-install"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: cluster-setup
+          image: {{ .Values.autoSetup.repository }}:{{ .Values.autoSetup.tag }}
+          imagePullPolicy: {{ .Values.autoSetup.pullPolicy }}
+          command:
+            - 'sh'
+            - '-c'
+            - 'curl -s http://$COUCHDB_ADDRESS/_cluster_setup -X POST -H "Content-Type: application/json" -d "{\"action\": \"finish_cluster\"}" -u $COUCHDB_ADMIN:$COUCHDB_PASS && export IFS=","; for db_name in $DEFAULT_DBS; do curl -X PUT http://$COUCHDB_ADDRESS/$db_name -u $COUCHDB_ADMIN:$COUCHDB_PASS; done'
+          env:
+            - name: DEFAULT_DBS
+              value: {{ join "," .Values.autoSetup.defaultDatabases }}
+            - name: COUCHDB_ADDRESS
+              value: "{{ template "couchdb.svcname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.externalPort}}"
+            - name: COUCHDB_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminUsername
+            - name: COUCHDB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminPassword
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+{{- end -}}

--- a/couchdb/templates/secrets.yaml
+++ b/couchdb/templates/secrets.yaml
@@ -15,7 +15,7 @@ data:
   {{- $erlangCookieArgs := dict "key" "erlangCookie" "ns" $.Release.Namespace "secretName" (include "couchdb.fullname" .) "secret" .Values.erlangFlags.setcookie }}
   erlangCookie: {{ template "couchdb.defaultsecret-stateful" $erlangCookieArgs }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
-{{- if  .Values.adminHash  }}
-  password.ini: {{ tpl (.Files.Get "password.ini") . | b64enc }}
+{{- if .Values.adminHash -}}
+  adminHash: {{ .Values.adminHash | b64enc | quote }}
 {{- end -}}
 {{- end -}}

--- a/couchdb/templates/secrets.yaml
+++ b/couchdb/templates/secrets.yaml
@@ -15,7 +15,7 @@ data:
   {{- $erlangCookieArgs := dict "key" "erlangCookie" "ns" $.Release.Namespace "secretName" (include "couchdb.fullname" .) "secret" .Values.erlangFlags.setcookie }}
   erlangCookie: {{ template "couchdb.defaultsecret-stateful" $erlangCookieArgs }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
-{{- if .Values.adminHash -}}
+{{- if  .Values.adminHash  }}
   adminHash: {{ .Values.adminHash | b64enc | quote }}
 {{- end -}}
 {{- end -}}

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -52,11 +52,19 @@ spec:
         - name: admin-hash-copy
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
-          command: ['sh','-c','cp /tmp/password.ini /local.d/ ;']
+          env:
+            - name: "ADMINUSERNAME"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminUsername
+            - name: "ADMINHASH"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminHash
+          command: ['sh','-c','echo -e "[admins]\n$ADMINUSERNAME = $ADMINHASH" > /local.d/password.ini ;']
           volumeMounts:
-            - name: admin-password
-              mountPath: /tmp/password.ini
-              subPath: "password.ini"
             - name: local-config-storage
               mountPath: /local.d
 {{- end }}
@@ -194,9 +202,6 @@ spec:
 {{- if .Values.adminHash }}
         - name: local-config-storage
           emptyDir: {}
-        - name: admin-password
-          secret:
-            secretName: {{ template "couchdb.fullname" . }}
 {{- end -}}
 
 {{- if not .Values.persistentVolume.enabled }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -9,6 +9,20 @@ clusterSize: 3
 # ref: https://kubernetes.io/docs/concepts/configuration/secret/
 allowAdminParty: false
 
+# Set it to true to automatically enable the cluster after installation.
+# It will create a post-install job that will send the {"action": "finish_cluster"}
+# message to CouchDB to finalize the cluster and add the defaultDatabases listed.
+# Note that this job needs service.enabled to be set to true and if you use adminHash,
+# a valid adminPassword in the secret. Also set the --wait flag when you install to
+# avoid first jobs failure (helm install --wait ...)
+autoSetup:
+  enabled: false
+  repository: alpine/curl
+  tag: latest
+  pullPolicy: Always
+  defaultDatabases:
+    - _global_changes
+
 # -- If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will
 # be created containing auto-generated credentials. Users who prefer to set
 # these values themselves have a couple of options:


### PR DESCRIPTION

<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:
It simplifies the secret. Instead of relying on password.ini for the adminHash, it simply stores the value. It helps users better manage their own secret files when they set `createAdminSecret` to false. 

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
