### PR TITLE
fix: set github pages path to ~

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -11,3 +11,4 @@ github:
       required_linear_history: true
     gh-pages: {}
   ghp_branch: gh-pages
+  ghp_path: ~


### PR DESCRIPTION
To workaround https://issues.apache.org/jira/browse/INFRA-24071, explicitly set the `ghp_path` to a value other than `/docs`. This should force the branch root folder to be used when compiling github pages.