### PR TITLE
chore: update chart-testing dependencies

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v3.5.0
-readonly KIND_VERSION=v0.11.1
+readonly CT_VERSION=v3.7.1
+readonly KIND_VERSION=v0.17.0
 readonly CLUSTER_NAME=chart-testing
-readonly K8S_VERSION=v1.19.7@sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
+readonly K8S_VERSION=v1.25.3
 
 run_ct_container() {
     echo 'Running ct container...'

--- a/test/local-path-provisioner.yaml
+++ b/test/local-path-provisioner.yaml
@@ -42,7 +42,7 @@ subjects:
   name: local-path-provisioner-service-account
   namespace: local-path-storage
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: local-path-provisioner


### PR DESCRIPTION
 * Update chart-testing to v3.7.1
 * Update kind to v0.17.0
 * Test against Kubernetes 1.25. The specific SHA is not specified to ensure image updates are picked up and the image for the appropriate cpu architecture are pulled.

This fixes running the tests on M1 macs (and confirmed the also run in GitHub actions)