### PR TITLE
Use multi platform image for autosetup

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.1.0
+version: 4.1.1
 appVersion: 3.2.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -18,7 +18,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
-  --version=4.1.0 \
+  --version=4.1.1 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -44,7 +44,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.1.0 \
+  --version=4.1.1 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -78,7 +78,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.1.0 \
+  --version=4.1.1 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -133,7 +133,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=4.1.0 couchdb/couchdb
+$ helm upgrade my-release --version=4.1.1 couchdb/couchdb
 ```
 
 ## Configuration
@@ -194,7 +194,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `tolerations`                        |                                                                                                                                                              |
 | `resources`                          |                                                                                                                                                              |
 | `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure) |
-| `autoSetup.image.repository`         | alpine/curl                                                                                                                                                  |
+| `autoSetup.image.repository`         | curlimages/curl                                                                                                                                                  |
 | `autoSetup.image.tag`                | latest                                                                                                                                                       |
 | `autoSetup.image.pullPolicy`         | Always                                                                                                                                                       |
 | `autoSetup.defaultDatabases`         | [`_global_changes`]                                                                                                                                          |

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -18,7 +18,7 @@ allowAdminParty: false
 autoSetup:
   enabled: false
   image:
-    repository: alpine/curl
+    repository: curlimages/curl
     tag: latest
     pullPolicy: Always
   defaultDatabases:


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:
This replaces the alpine/curl image used for auto setup with [curlimages/curl](https://hub.docker.com/r/curlimages/curl), the reason is the alpine/curl image has not been updated in over a year and it is also not a multi-platform image. While trying to use the auto setup feature on a arm64 cluster I encountered an exec format error and had to swap out the alpine image for the one in this PR. By using this image by default, other arm64 users will be able to use the auto setup functionality without needing to locate a compatible image and find the value to swap it out.


#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [x] e2e tests pass (also have run against my arm64 cluster)
- [x] Variables are documented in the README.md

```
------------------------------------------------------------------------------------------------------------------------
 ✔︎ couchdb => (version: "4.1.1", path: "couchdb")
------------------------------------------------------------------------------------------------------------------------
All charts linted and installed successfully

Removing ct container...
Deleting cluster "chart-testing" ...
Done!
```
