### PR TITLE
Updating CouchDB version from 3.2.1 to 3.3.2

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: couchdb
-version: 4.3.0
-appVersion: 3.2.1
+version: 4.3.1
+appVersion: 3.2.3
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.

--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: couchdb
 version: 4.3.1
-appVersion: 3.2.3
+appVersion: 3.3.2
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.3.2](https://img.shields.io/badge/AppVersion-3.3.2-informational?style=flat-square)
+![Version: 4.3.1](https://img.shields.io/badge/Version-4.3.1-informational?style=flat-square) ![AppVersion: 3.3.2](https://img.shields.io/badge/AppVersion-3.3.2-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.2.3](https://img.shields.io/badge/AppVersion-3.2.3-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -172,7 +172,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminHash`                            |                                                  |
 | `cookieAuthSecret`                     | auto-generated                                   |
 | `image.repository`                     | couchdb                                          |
-| `image.tag`                            | 3.2.1                                            |
+| `image.tag`                            | 3.2.3                                            |
 | `image.pullPolicy`                     | IfNotPresent                                     |
 | `searchImage.repository`               | kocolosk/couchdb-search                          |
 | `searchImage.tag`                      | 0.1.0                                            |

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.2.3](https://img.shields.io/badge/AppVersion-3.2.3-informational?style=flat-square)
+![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.3.2](https://img.shields.io/badge/AppVersion-3.3.2-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -172,7 +172,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminHash`                            |                                                  |
 | `cookieAuthSecret`                     | auto-generated                                   |
 | `image.repository`                     | couchdb                                          |
-| `image.tag`                            | 3.2.3                                            |
+| `image.tag`                            | 3.3.2                                            |
 | `image.pullPolicy`                     | IfNotPresent                                     |
 | `searchImage.repository`               | kocolosk/couchdb-search                          |
 | `searchImage.tag`                      | 0.1.0                                            |

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -163,7 +163,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminHash`                          |                                                                                                                                                              |
 | `cookieAuthSecret`                   | auto-generated                                                                                                                                               |
 | `image.repository`                   | couchdb                                                                                                                                                      |
-| `image.tag`                          | 3.2.3                                                                                                                                                        |
+| `image.tag`                          | 3.3.2                                                                                                                                                        |
 | `image.pullPolicy`                   | IfNotPresent                                                                                                                                                 |
 | `searchImage.repository`             | kocolosk/couchdb-search                                                                                                                                      |
 | `searchImage.tag`                    | 0.1.0                                                                                                                                                        |

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -163,7 +163,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminHash`                          |                                                                                                                                                              |
 | `cookieAuthSecret`                   | auto-generated                                                                                                                                               |
 | `image.repository`                   | couchdb                                                                                                                                                      |
-| `image.tag`                          | 3.2.1                                                                                                                                                        |
+| `image.tag`                          | 3.2.3                                                                                                                                                        |
 | `image.pullPolicy`                   | IfNotPresent                                                                                                                                                 |
 | `searchImage.repository`             | kocolosk/couchdb-search                                                                                                                                      |
 | `searchImage.tag`                    | 0.1.0                                                                                                                                                        |

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -78,7 +78,7 @@ persistentVolume:
 ## The CouchDB image
 image:
   repository: couchdb
-  tag: 3.2.1
+  tag: 3.3.2
   pullPolicy: IfNotPresent
 
 ## Experimental integration with Lucene-powered fulltext search


### PR DESCRIPTION
#### What this PR does / why we need it:
Update CouchDB from 3.2.1 to 3.3.2. The latest version fixses the CVE-2023-26268 as stated in the [release notes
](https://docs.couchdb.org/en/latest/whatsnew/3.3.html#version-3-3-2)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
