### PR TITLE
Add .Values.persistentVolume.selfManaged so PVCs can be managed 

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.4.0
+version: 4.4.1
 appVersion: 3.3.2
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -188,6 +188,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `ingress.tls`                          |                                                  |
 | `persistentVolume.accessModes`         | ReadWriteOnce                                    |
 | `persistentVolume.storageClass`        | Default for the Kube cluster                     |
+| `persistentVolume.selfManaged`         | Set selfManaged to true if you want to provide the chart with existing PVCs created outside of the scope of this helm chart.                                          |
 | `persistentVolume.annotations`         | {}                                               |
 | `persistentVolume.existingClaims`      | [] (a list of existing PV/PVC volume value objects with `volumeName`, `claimName`, `persistentVolumeName` and `volumeSource` defined)                                                                |
 | `persistentVolume.volumeName`          |                                                  |

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -178,6 +178,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `ingress.tls`                        |                                                                                                                                                              |
 | `persistentVolume.accessModes`       | ReadWriteOnce                                                                                                                                                |
 | `persistentVolume.storageClass`      | Default for the Kube cluster                                                                                                                                 |
+| `persistentVolume.selfManaged`       | Set selfManaged to true if you want to provide the chart with existing PVCs created outside of the scope of this helm chart.                                 |
 | `persistentVolume.annotations`       | {}                                                                                                                                                           |
 | `podDisruptionBudget.enabled`        | false                                                                                                                                                        |
 | `podDisruptionBudget.minAvailable`   | nil                                                                                                                                                          |

--- a/couchdb/templates/persistentvolume.yaml
+++ b/couchdb/templates/persistentvolume.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistentVolume.enabled .Values.persistentVolume.existingClaims -}}
+{{- if and (and .Values.persistentVolume.enabled .Values.persistentVolume.existingClaims) (not .Values.persistentVolume.selfManaged) -}}
 {{- range $claim := .Values.persistentVolume.existingClaims }}
 apiVersion: v1
 kind: PersistentVolume

--- a/couchdb/templates/persistentvolumeclaim.yaml
+++ b/couchdb/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistentVolume.enabled .Values.persistentVolume.existingClaims -}}
+{{- if and (and .Values.persistentVolume.enabled .Values.persistentVolume.existingClaims) (not .Values.persistentVolume.selfManaged) -}}
 {{- $context := . }}
 {{- range $claim := .Values.persistentVolume.existingClaims }}
 apiVersion: v1

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -67,6 +67,9 @@ serviceAccount:
 # provisioner.
 persistentVolume:
   enabled: false
+  # Set selfManaged to true if you want to provide the chart with existing PVCs created outside of the scope of this helm chart. 
+  # Warning: If you have existing PVCs generated through the helm chart and you set this to true, it will end up deleting the PVCs unless you remove the owner reference of helm from the PVCs/PVs OR if you keep a snapshot/backup and restore yourself. 
+  selfManaged: false
   # NOTE: the number of existing claims must match the cluster size
   existingClaims: []
   annotations: {}


### PR DESCRIPTION
outside of the helm-chart for consistency and to prevent accidental deletions by helm.

#### What this PR does / why we need it:

Currently the chart manages the PVCs for the statefulset. Which means any re-installation of the chart will result in data loss unless snapshots/backups have been taken beforehand. 
This PR allows for opting out of that behavior and managing the PVCs separately from the chart.
Anyone setting selfManaged: true will have to have taken a backup of the data before hand OR have modified the owner annotations on the PV/PVC resources to prevent their deletion.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
