### PR TITLE
Add service.targetPort to values

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.4.0
+version: 4.4.1
 appVersion: 3.3.2
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,9 @@
 # NEWS
 
+## 4.4.1
+
+- Add possibility to customize `service.targetPort` from values. Set default to 5984.
+
 ## 4.3.0
 
 - Use Ingress `className` instead of `kubernetes.io/ingress.class` annotation which has been deprecated since Kubernetes 1.18+ ([#69](https://github.com/apache/couchdb-helm/issues/69))

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -165,77 +165,78 @@ A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
 
-| Parameter                              | Default                                          |
-| -------------------------------------- | ------------------------------------------------ |
-| `adminUsername`                        | admin                                            |
-| `adminPassword`                        | auto-generated                                   |
-| `adminHash`                            |                                                  |
-| `cookieAuthSecret`                     | auto-generated                                   |
-| `image.repository`                     | couchdb                                          |
-| `image.tag`                            | 3.3.2                                            |
-| `image.pullPolicy`                     | IfNotPresent                                     |
-| `searchImage.repository`               | kocolosk/couchdb-search                          |
-| `searchImage.tag`                      | 0.1.0                                            |
-| `searchImage.pullPolicy`               | IfNotPresent                                     |
-| `initImage.repository`                 | busybox                                          |
-| `initImage.tag`                        | latest                                           |
-| `initImage.pullPolicy`                 | Always                                           |
-| `ingress.enabled`                      | false                                            |
-| `ingress.className`                    |                                                  |
-| `ingress.hosts`                        | chart-example.local                              |
-| `ingress.annotations`                  |                                                  |
-| `ingress.path`                         | /                                                |
-| `ingress.tls`                          |                                                  |
-| `persistentVolume.accessModes`         | ReadWriteOnce                                    |
-| `persistentVolume.storageClass`        | Default for the Kube cluster                     |
-| `persistentVolume.annotations`         | {}                                               |
-| `persistentVolume.existingClaims`      | [] (a list of existing PV/PVC volume value objects with `volumeName`, `claimName`, `persistentVolumeName` and `volumeSource` defined)                                                                |
-| `persistentVolume.volumeName`          |                                                  |
-| `persistentVolume.claimName`           |                                                  |
-| `persistentVolume.volumeSource`        |                                                  |
-| `persistentVolume.annotations`         | {}                                               |
-| `podDisruptionBudget.enabled`          | false                                            |
-| `podDisruptionBudget.minAvailable`     | nil                                              |
-| `podDisruptionBudget.maxUnavailable`   | 1                                                |
-| `podManagementPolicy`                  | Parallel                                         |
-| `affinity`                             |                                                  |
-| `topologySpreadConstraints`            |                                                  |
-| `annotations`                          |                                                  |
-| `tolerations`                          |                                                  |
-| `resources`                            |                                                  |
-| `autoSetup.enabled`                    | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure)                                         |
-| `autoSetup.image.repository`           | curlimages/curl                                  |
-| `autoSetup.image.tag`                  | latest                                           |
-| `autoSetup.image.pullPolicy`           | Always                                           |
-| `autoSetup.defaultDatabases`           | [`_global_changes`]                              |
-| `service.annotations`                  |                                                  |
-| `service.enabled`                      | true                                             |
-| `service.type`                         | ClusterIP                                        |
-| `service.externalPort`                 | 5984                                             |
-| `dns.clusterDomainSuffix`              | cluster.local                                    |
-| `networkPolicy.enabled`                | true                                             |
-| `serviceAccount.enabled`               | true                                             |
-| `serviceAccount.create`                | true                                             |
-| `serviceAccount.imagePullSecrets`      |                                                  |
-| `sidecars`                             | {}                                               |
-| `livenessProbe.enabled`                | true                                             |
-| `livenessProbe.failureThreshold`       | 3                                                |
-| `livenessProbe.initialDelaySeconds`    | 0                                                |
-| `livenessProbe.periodSeconds`          | 10                                               |
-| `livenessProbe.successThreshold`       | 1                                                |
-| `livenessProbe.timeoutSeconds`         | 1                                                |
-| `readinessProbe.enabled`               | true                                             |
-| `readinessProbe.failureThreshold`      | 3                                                |
-| `readinessProbe.initialDelaySeconds`   | 0                                                |
-| `readinessProbe.periodSeconds`         | 10                                               |
-| `readinessProbe.successThreshold`      | 1                                                |
-| `readinessProbe.timeoutSeconds`        | 1                                                |
-| `prometheusPort.enabled`               | false                                            |
-| `prometheusPort.port`                  | 17896                                            |
-| `prometheusPort.bind_address`          | 0.0.0.0                                          |
-| `placementConfig.enabled`              | false                                            |
-| `placementConfig.image.repository`     | caligrafix/couchdb-autoscaler-placement-manager  |
-| `placementConfig.image.tag`            | 0.1.0                                            |
+| Parameter                            | Default                                          |
+|--------------------------------------| ------------------------------------------------ |
+| `adminUsername`                      | admin                                            |
+| `adminPassword`                      | auto-generated                                   |
+| `adminHash`                          |                                                  |
+| `cookieAuthSecret`                   | auto-generated                                   |
+| `image.repository`                   | couchdb                                          |
+| `image.tag`                          | 3.3.2                                            |
+| `image.pullPolicy`                   | IfNotPresent                                     |
+| `searchImage.repository`             | kocolosk/couchdb-search                          |
+| `searchImage.tag`                    | 0.1.0                                            |
+| `searchImage.pullPolicy`             | IfNotPresent                                     |
+| `initImage.repository`               | busybox                                          |
+| `initImage.tag`                      | latest                                           |
+| `initImage.pullPolicy`               | Always                                           |
+| `ingress.enabled`                    | false                                            |
+| `ingress.className`                  |                                                  |
+| `ingress.hosts`                      | chart-example.local                              |
+| `ingress.annotations`                |                                                  |
+| `ingress.path`                       | /                                                |
+| `ingress.tls`                        |                                                  |
+| `persistentVolume.accessModes`       | ReadWriteOnce                                    |
+| `persistentVolume.storageClass`      | Default for the Kube cluster                     |
+| `persistentVolume.annotations`       | {}                                               |
+| `persistentVolume.existingClaims`    | [] (a list of existing PV/PVC volume value objects with `volumeName`, `claimName`, `persistentVolumeName` and `volumeSource` defined)                                                                |
+| `persistentVolume.volumeName`        |                                                  |
+| `persistentVolume.claimName`         |                                                  |
+| `persistentVolume.volumeSource`      |                                                  |
+| `persistentVolume.annotations`       | {}                                               |
+| `podDisruptionBudget.enabled`        | false                                            |
+| `podDisruptionBudget.minAvailable`   | nil                                              |
+| `podDisruptionBudget.maxUnavailable` | 1                                                |
+| `podManagementPolicy`                | Parallel                                         |
+| `affinity`                           |                                                  |
+| `topologySpreadConstraints`          |                                                  |
+| `annotations`                        |                                                  |
+| `tolerations`                        |                                                  |
+| `resources`                          |                                                  |
+| `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure)                                         |
+| `autoSetup.image.repository`         | curlimages/curl                                  |
+| `autoSetup.image.tag`                | latest                                           |
+| `autoSetup.image.pullPolicy`         | Always                                           |
+| `autoSetup.defaultDatabases`         | [`_global_changes`]                              |
+| `service.annotations`                |                                                  |
+| `service.enabled`                    | true                                             |
+| `service.type`                       | ClusterIP                                        |
+| `service.externalPort`               | 5984                                             |
+| `service.targetPort`                 | 5984                                             |
+| `dns.clusterDomainSuffix`            | cluster.local                                    |
+| `networkPolicy.enabled`              | true                                             |
+| `serviceAccount.enabled`             | true                                             |
+| `serviceAccount.create`              | true                                             |
+| `serviceAccount.imagePullSecrets`    |                                                  |
+| `sidecars`                           | {}                                               |
+| `livenessProbe.enabled`              | true                                             |
+| `livenessProbe.failureThreshold`     | 3                                                |
+| `livenessProbe.initialDelaySeconds`  | 0                                                |
+| `livenessProbe.periodSeconds`        | 10                                               |
+| `livenessProbe.successThreshold`     | 1                                                |
+| `livenessProbe.timeoutSeconds`       | 1                                                |
+| `readinessProbe.enabled`             | true                                             |
+| `readinessProbe.failureThreshold`    | 3                                                |
+| `readinessProbe.initialDelaySeconds` | 0                                                |
+| `readinessProbe.periodSeconds`       | 10                                               |
+| `readinessProbe.successThreshold`    | 1                                                |
+| `readinessProbe.timeoutSeconds`      | 1                                                |
+| `prometheusPort.enabled`             | false                                            |
+| `prometheusPort.port`                | 17896                                            |
+| `prometheusPort.bind_address`        | 0.0.0.0                                          |
+| `placementConfig.enabled`            | false                                            |
+| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager  |
+| `placementConfig.image.tag`          | 0.1.0                                            |
 
 ## Feedback, Issues, Contributing
 

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -197,6 +197,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `service.enabled`                    | true                                                                                                                                                         |
 | `service.type`                       | ClusterIP                                                                                                                                                    |
 | `service.externalPort`               | 5984                                                                                                                                                         |
+| `service.targetPort`                 | 5984                                                                                                                                                         |
 | `dns.clusterDomainSuffix`            | cluster.local                                                                                                                                                |
 | `networkPolicy.enabled`              | true                                                                                                                                                         |
 | `serviceAccount.enabled`             | true                                                                                                                                                         |

--- a/couchdb/templates/service.yaml
+++ b/couchdb/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   ports:
     - port: {{ .Values.service.externalPort }}
       protocol: TCP
-      targetPort: 5984
+      targetPort: {{ .Values.service.targetPort }}
   type: {{ .Values.service.type }}
   selector:
 {{ include "couchdb.ss.selector" . | indent 4 }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -139,6 +139,7 @@ service:
   enabled: true
   type: ClusterIP
   externalPort: 5984
+  targetPort: 5984
   labels: {}
 
 ## An Ingress resource can provide name-based virtual hosting and TLS


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

It allows to customize the `service.targetPort` from the values.yaml.

We need to be able to send the calls to the port of a proxy sidecar container. The proxy redirects our calls to the CouchDB port so we should be able to decide which container/port handles the calls.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
