### PR TITLE
Added missing init-container resources 

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.4.3
+version: 4.4.4
 appVersion: 3.3.2
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -48,6 +48,8 @@ spec:
             mountPath: /tmp/
           - name: config-storage
             mountPath: /default.d
+          resources:
+{{ toYaml .Values.initResources | indent 12 }}
 {{- if .Values.adminHash }}
         - name: admin-hash-copy
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"


### PR DESCRIPTION

#### What this PR does / why we need it:
In #128 the PR accidentally only added the `resources` key to one of the two possible init containers. This PR adds the missing section.

#### Which issue this PR fixes
- fixes #125 

#### Special notes for your reviewer:
Version was bumped to 4.4.4

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
