### PR TITLE
Docs: Update `couchdb/README.md` - change `cookeAuthSecret` to `erlangCookie` and make code blocks easier to copy via copy button on github

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -57,10 +57,10 @@ kubectl get secret my-release-couchdb -o go-template='{{ .data.adminPassword }}'
 ```
 
 If you prefer to configure the admin credentials directly you can create a
-Secret containing `adminUsername`, `adminPassword` and `erlangCookie` keys:
+Secret containing `adminUsername`, `adminPassword`, `cookieAuthSecret` and `erlangCookie` keys:
 
 ```bash
-kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=erlangCookie=baz
+kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=erlangCookie=baz --from-literal=cookieAuthSecret=beep
 ```
 
 If you want to set the `adminHash` directly to achieve consistent salts between
@@ -70,6 +70,7 @@ different nodes you need to add it to the secret:
 kubectl create secret generic my-release-couchdb \
    --from-literal=adminUsername=foo \
    --from-literal=erlangCookie=baz \
+   --from-literal=cookieAuthSecret=beep \
    --from-literal=adminHash=-pbkdf2-d4b887da....
 ```
 
@@ -143,10 +144,10 @@ CouchDB chart and their default values:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| allowAdminParty | bool | `false` | If allowAdminParty is enabled the cluster will start up without any database administrator account; i.e., all users will be granted administrative access. Otherwise, the system will look for a Secret called <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and `erlangCookie` keys. See the `createAdminSecret` flag. ref: https://kubernetes.io/docs/concepts/configuration/secret/ |
+| allowAdminParty | bool | `false` | If allowAdminParty is enabled the cluster will start up without any database administrator account; i.e., all users will be granted administrative access. Otherwise, the system will look for a Secret called <ReleaseName>-couchdb containing `adminUsername`, `adminPassword`, `cookieAuthSecret`, and `erlangCookie` keys. See the `createAdminSecret` flag. ref: https://kubernetes.io/docs/concepts/configuration/secret/ |
 | clusterSize | int | `3` | the initial number of nodes in the CouchDB cluster. |
 | couchdbConfig | object | `{"chttpd":{"bind_address":"any","require_valid_user":false}}` | couchdbConfig will override default CouchDB configuration settings. The contents of this map are reformatted into a .ini file laid down by a ConfigMap object. ref: http://docs.couchdb.org/en/latest/config/index.html |
-| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options: 1) The `adminUsername`, `adminPassword`, `adminHash`, and `erlangCookie`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace. 2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
+| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options: 1) The `adminUsername`, `adminPassword`, `adminHash`, `cookieAuthSecret`, and `erlangCookie`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace. 2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
 | enableSearch | bool | `false` | Flip this to flag to include the Search container in each Pod |
 | erlangFlags | object | `{"name":"couchdb"}` | erlangFlags is a map that is passed to the Erlang VM as flags using the ERL_FLAGS env. The `name` flag is required to establish connectivity between cluster nodes. ref: http://erlang.org/doc/man/erl.html#init_flags |
 | persistentVolume | object | `{"accessModes":["ReadWriteOnce"],"enabled":false,"size":"10Gi"}` | The storage volume used by each Pod in the StatefulSet. If a persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral local storage. Setting the storageClass attribute to "-" disables dynamic provisioning of Persistent Volumes; leaving it unset will invoke the default provisioner. |
@@ -170,6 +171,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminUsername`                      | admin                                            |
 | `adminPassword`                      | auto-generated                                   |
 | `adminHash`                          |                                                  |
+| `cookieAuthSecret`                   | auto-generated                                  |
 | `erlangCookie`                       | auto-generated                                   |
 | `image.repository`                   | couchdb                                          |
 | `image.tag`                          | 3.3.3                                            |

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -16,8 +16,8 @@ storage volumes to each Pod in the Deployment.
 ## TL;DR
 
 ```bash
-$ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm install couchdb/couchdb \
+helm repo add couchdb https://apache.github.io/couchdb-helm
+helm install couchdb/couchdb \
   --version=4.4.1 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
@@ -35,14 +35,14 @@ To install the chart with the release name `my-release`:
 Add the CouchDB Helm repository:
 
 ```bash
-$ helm repo add couchdb https://apache.github.io/couchdb-helm
+helm repo add couchdb https://apache.github.io/couchdb-helm
 ```
 
 Afterwards install the chart replacing the UUID
 `decafbaddecafbaddecafbaddecafbad` with a custom one:
 
 ```bash
-$ helm install \
+helm install \
   --name my-release \
   --version=4.4.1 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
@@ -53,30 +53,30 @@ This will create a Secret containing the admin credentials for the cluster.
 Those credentials can be retrieved as follows:
 
 ```bash
-$ kubectl get secret my-release-couchdb -o go-template='{{ .data.adminPassword }}' | base64 --decode
+kubectl get secret my-release-couchdb -o go-template='{{ .data.adminPassword }}' | base64 --decode
 ```
 
 If you prefer to configure the admin credentials directly you can create a
-Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
+Secret containing `adminUsername`, `adminPassword` and `erlangCookie` keys:
 
 ```bash
-$  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
+kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=erlangCookie=baz
 ```
 
 If you want to set the `adminHash` directly to achieve consistent salts between
 different nodes you need to add it to the secret:
 
 ```bash
-$  kubectl create secret generic my-release-couchdb \
+kubectl create secret generic my-release-couchdb \
    --from-literal=adminUsername=foo \
-   --from-literal=cookieAuthSecret=baz \
+   --from-literal=erlangCookie=baz \
    --from-literal=adminHash=-pbkdf2-d4b887da....
 ```
 
 and then install the chart while overriding the `createAdminSecret` setting:
 
 ```bash
-$ helm install \
+helm install \
   --name my-release \
   --version=4.4.1 \
   --set createAdminSecret=false \
@@ -95,7 +95,7 @@ the parameters that can be configured during installation.
 To uninstall/delete the `my-release` Deployment:
 
 ```bash
-$ helm delete my-release
+helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and
@@ -113,7 +113,7 @@ Therefore, you need to generate a UUID and supply it as a value during the
 upgrade as follows:
 
 ```bash
-$ helm upgrade <release-name> \
+helm upgrade <release-name> \
   --version=3.6.4 \
   --reuse-values \
   --set couchdbConfig.couchdb.uuid=<UUID> \
@@ -132,8 +132,8 @@ This chart replaces the `stable/couchdb` chart previously hosted by Helm and con
 version semantics. You can upgrade directly from `stable/couchdb` to this chart using:
 
 ```bash
-$ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=4.4.1 couchdb/couchdb
+helm repo add couchdb https://apache.github.io/couchdb-helm
+helm upgrade my-release --version=4.4.1 couchdb/couchdb
 ```
 
 ## Configuration
@@ -143,10 +143,10 @@ CouchDB chart and their default values:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| allowAdminParty | bool | `false` | If allowAdminParty is enabled the cluster will start up without any database administrator account; i.e., all users will be granted administrative access. Otherwise, the system will look for a Secret called <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys. See the `createAdminSecret` flag. ref: https://kubernetes.io/docs/concepts/configuration/secret/ |
+| allowAdminParty | bool | `false` | If allowAdminParty is enabled the cluster will start up without any database administrator account; i.e., all users will be granted administrative access. Otherwise, the system will look for a Secret called <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and `erlangCookie` keys. See the `createAdminSecret` flag. ref: https://kubernetes.io/docs/concepts/configuration/secret/ |
 | clusterSize | int | `3` | the initial number of nodes in the CouchDB cluster. |
 | couchdbConfig | object | `{"chttpd":{"bind_address":"any","require_valid_user":false}}` | couchdbConfig will override default CouchDB configuration settings. The contents of this map are reformatted into a .ini file laid down by a ConfigMap object. ref: http://docs.couchdb.org/en/latest/config/index.html |
-| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options: 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace. 2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
+| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options: 1) The `adminUsername`, `adminPassword`, `adminHash`, and `erlangCookie`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace. 2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
 | enableSearch | bool | `false` | Flip this to flag to include the Search container in each Pod |
 | erlangFlags | object | `{"name":"couchdb"}` | erlangFlags is a map that is passed to the Erlang VM as flags using the ERL_FLAGS env. The `name` flag is required to establish connectivity between cluster nodes. ref: http://erlang.org/doc/man/erl.html#init_flags |
 | persistentVolume | object | `{"accessModes":["ReadWriteOnce"],"enabled":false,"size":"10Gi"}` | The storage volume used by each Pod in the StatefulSet. If a persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral local storage. Setting the storageClass attribute to "-" disables dynamic provisioning of Persistent Volumes; leaving it unset will invoke the default provisioner. |
@@ -170,7 +170,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminUsername`                      | admin                                            |
 | `adminPassword`                      | auto-generated                                   |
 | `adminHash`                          |                                                  |
-| `cookieAuthSecret`                   | auto-generated                                   |
+| `erlangCookie`                   | auto-generated                                   |
 | `image.repository`                   | couchdb                                          |
 | `image.tag`                          | 3.3.2                                            |
 | `image.pullPolicy`                   | IfNotPresent                                     |

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -170,7 +170,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminUsername`                      | admin                                            |
 | `adminPassword`                      | auto-generated                                   |
 | `adminHash`                          |                                                  |
-| `erlangCookie`                   | auto-generated                                   |
+| `erlangCookie`                       | auto-generated                                   |
 | `image.repository`                   | couchdb                                          |
 | `image.tag`                          | 3.3.2                                            |
 | `image.pullPolicy`                   | IfNotPresent                                     |


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

This updates `cookeAuthSecret` to `erlangCookie` in the README for the helm chart directory, as that is what couchdb looks for in the secret can pre-generate.

I've also updated the code blocks to not have `$ ` in front of each command, so that users can more easily copy and paste the commands to test them. This is particularly helpful for users with disabilities as they don't need to mind the space and dollar sign when trying out the commands in the docs.

#### Which issue this PR fixes
  - doesn't completely cover, but helps address https://github.com/apache/couchdb-helm/issues/101

#### Special notes for your reviewer:
Thanks for maintaining this helm chart!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Variables are documented in the README.md
