### PR TITLE
feat: allow configure persistentVolumeClaimRetentionPolicy

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.5.1
+version: 4.5.2
 appVersion: 3.3.3
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.5.0
+version: 4.5.1
 appVersion: 3.3.2
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -194,6 +194,9 @@ A variety of other parameters are also configurable. See the comments in the
 | `persistentVolume.claimName`         |                                                  |
 | `persistentVolume.volumeSource`      |                                                  |
 | `persistentVolume.annotations`       | {}                                               |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Field controls if and how PVCs are deleted during the lifecycle                                            |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Configures the volume retention behavior that applies when the replica count of the StatefulSet is reduced |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Configures the volume retention behavior that applies when the StatefulSet is deleted                      |
 | `podDisruptionBudget.enabled`        | false                                            |
 | `podDisruptionBudget.minAvailable`   | nil                                              |
 | `podDisruptionBudget.maxUnavailable` | 1                                                |

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.5.1](https://img.shields.io/badge/Version-4.5.1-informational?style=flat-square) ![AppVersion: 3.3.3](https://img.shields.io/badge/AppVersion-3.3.3-informational?style=flat-square)
+![Version: 4.5.2](https://img.shields.io/badge/Version-4.5.2-informational?style=flat-square) ![AppVersion: 3.3.3](https://img.shields.io/badge/AppVersion-3.3.3-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -18,7 +18,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
-  --version=4.5.1 \
+  --version=4.5.2 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -44,7 +44,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.5.1 \
+  --version=4.5.2 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -78,7 +78,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.5.1 \
+  --version=4.5.2 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -133,7 +133,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=4.5.1 couchdb/couchdb
+$ helm upgrade my-release --version=4.5.2 couchdb/couchdb
 ```
 
 ## Configuration

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -236,6 +236,11 @@ spec:
             claimName: {{ $claim.claimName }}
         {{- end }}
 {{- else }}
+{{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+{{- end }}
   volumeClaimTemplates:
     - metadata:
         {{- include "persistentVolume.metadata" (dict "context" .) | nindent 8 }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -75,6 +75,14 @@ persistentVolume:
   size: 10Gi
   # storageClass: "-"
 
+# Field controls if and how PVCs are deleted during the lifecycle
+# of a StatefulSet
+# ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+persistentVolumeClaimRetentionPolicy:
+  enabled: false
+  whenScaled: Retain
+  whenDeleted: Retain
+
 ## The CouchDB image
 image:
   repository: couchdb

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -75,6 +75,7 @@ persistentVolume:
   size: 10Gi
   # storageClass: "-"
 
+# Experimental - FEATURE STATE: Kubernetes v1.27 [beta]
 # Field controls if and how PVCs are deleted during the lifecycle
 # of a StatefulSet
 # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

Allow to specify a persistentVolumeClaimRetentionPolicy in both the primary and secondary StatefulSet.

#### Special notes for your reviewer:

This allows for automatic cleanup of PVCs after deletion, etc. An example use case of this is for highly dynamic test environments, where cleaning up the PVCs after deletion of the helm chart is preferred.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
