### PR TITLE
fix(imagePullSecrets): restore ability to set image pull secrets

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.5.2
+version: 4.5.3
 appVersion: 3.3.3
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,9 @@
 # NEWS
 
+## 4.5.3
+
+- Fix ability to define pull secrets using `imagePullSecrets`. 
+
 ## 4.5.2
 
 - Allow to specify a persistentVolumeClaimRetentionPolicy in both the primary and secondary StatefulSet.

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.5.2](https://img.shields.io/badge/Version-4.5.2-informational?style=flat-square) ![AppVersion: 3.3.3](https://img.shields.io/badge/AppVersion-3.3.3-informational?style=flat-square)
+![Version: 4.5.3](https://img.shields.io/badge/Version-4.5.3-informational?style=flat-square) ![AppVersion: 3.3.3](https://img.shields.io/badge/AppVersion-3.3.3-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -18,7 +18,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
-  --version=4.5.2 \
+  --version=4.5.3 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -44,7 +44,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.5.2 \
+  --version=4.5.3 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -78,7 +78,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.5.2 \
+  --version=4.5.3 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -133,7 +133,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=4.5.2 couchdb/couchdb
+$ helm upgrade my-release --version=4.5.3 couchdb/couchdb
 ```
 
 ## Configuration
@@ -222,7 +222,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `networkPolicy.enabled`              | true                                             |
 | `serviceAccount.enabled`             | true                                             |
 | `serviceAccount.create`              | true                                             |
-| `serviceAccount.imagePullSecrets`    |                                                  |
+| `imagePullSecrets`                   |                                                  |
 | `sidecars`                           | {}                                               |
 | `livenessProbe.enabled`              | true                                             |
 | `livenessProbe.failureThreshold`     | 3                                                |

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -37,6 +37,9 @@ spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ template "couchdb.serviceAccount" . }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ .Values.imagePullSecrets | toYaml | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-copy
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -57,8 +57,9 @@ serviceAccount:
   enabled: true
   create: true
 # name:
+
 # imagePullSecrets:
-# - name: myimagepullsecret
+#   - name: myimagepullsecret
 
 # -- The storage volume used by each Pod in the StatefulSet. If a
 # persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

In the values.yaml file there is a commented out block referring to `imagePullSecrets` but this is not mapped into the statefulset. This restores the ability to use a private images that require a pull secret.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
