### PR TITLE
Support extraPorts in the service template.

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.5.3
+version: 4.5.4
 appVersion: 3.3.3
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,8 +1,12 @@
 # NEWS
 
+## 4.5.4
+
+- Expose `extraPorts` and `service.extraPorts` to allow specifying arbitrary ports to be exposed from the CouchDB pods
+
 ## 4.5.3
 
-- Fix ability to define pull secrets using `imagePullSecrets`. 
+- Fix ability to define pull secrets using `imagePullSecrets`.
 
 ## 4.5.2
 

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -171,6 +171,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminPassword`                      | auto-generated                                   |
 | `adminHash`                          |                                                  |
 | `cookieAuthSecret`                   | auto-generated                                   |
+| `extraPorts`                         | [] (a list of ContainerPort objects)             |
 | `image.repository`                   | couchdb                                          |
 | `image.tag`                          | 3.3.3                                            |
 | `image.pullPolicy`                   | IfNotPresent                                     |
@@ -218,6 +219,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `service.type`                       | ClusterIP                                        |
 | `service.externalPort`               | 5984                                             |
 | `service.targetPort`                 | 5984                                             |
+| `service.extraPorts`                 | [] (a list of ServicePort objects)               |
 | `dns.clusterDomainSuffix`            | cluster.local                                    |
 | `networkPolicy.enabled`              | true                                             |
 | `serviceAccount.enabled`             | true                                             |

--- a/couchdb/templates/service.yaml
+++ b/couchdb/templates/service.yaml
@@ -20,6 +20,9 @@ spec:
     - port: {{ .Values.service.externalPort }}
       protocol: TCP
       targetPort: {{ .Values.service.targetPort }}
+    {{ with .Values.service.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   type: {{ .Values.service.type }}
   selector:
 {{ include "couchdb.ss.selector" . | indent 4 }}

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -101,6 +101,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.prometheusPort.port }}
 {{- end }}
+{{ with .Values.extraPorts }}
+{{ toYaml . | indent 12 }}
+{{ end }}
           env:
 {{- if not .Values.allowAdminParty }}
             - name: COUCHDB_USER

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -160,9 +160,9 @@ service:
   #   targetPort: 4984
   #   protocol: TCP
 
-## If you need to expose any additional ports on the CouchDB pods, for example
-## if you're running a sidecar container that needs to be accessible from outside
-## of the pod, you can define them here.
+## If you need to expose any additional ports on the CouchDB container, for example
+## if you're running CouchDB container with additional processes that need to
+## be accessible outside of the pod, you can define them here.
 extraPorts: []
   # - name: sqs
   #   containerPort: 4984

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -155,6 +155,17 @@ service:
   targetPort: 5984
   labels: {}
   extraPorts: []
+  # - name: sqs
+  #   port: 4984
+  #   targetPort: 4984
+  #   protocol: TCP
+
+## If you need to expose any additional ports on the CouchDB pods, for example
+## if you're running a sidecar container that needs to be accessible from outside
+## of the pod, you can define them here.
+extraPorts: []
+  # - name: sqs
+  #   containerPort: 4984
 
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -154,6 +154,7 @@ service:
   externalPort: 5984
   targetPort: 5984
   labels: {}
+  extraPorts: []
 
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed


### PR DESCRIPTION
#### What this PR does / why we need it:

At [Budibase](https://budibase.com) we're making use of the CouchDB [structured query service](https://neighbourhood.ie/products-and-services/structured-query-server) (SQS) and as such need to communicate with the SQS binary running alongside CouchDB on port 4984. We've created our own `budibase/couchdb` image to run SQS alongside CouchDB.

To allow this, I've added two new options to `values.yaml`:

1. `extraPorts` -- to specify new ports to expose on the `StatefulSet` pods.
2. `service.extraPorts` -- to specify new ports to expose on the `Service`.

#### Special notes for your reviewer:

Before starting on this PR I ran `make test` and the tests passed. Now, though, when I run them I get the following error:

<details>

```
❯ make test
./test/e2e-kind.sh
Running ct container...
27098003d07177e9e3896e11506fe29a905fd7dcfc4fccc3add5a3b41bfe0368

Deleting cluster "chart-testing" ...
Creating cluster "chart-testing" ...
 ✓ Ensuring node image (kindest/node:v1.25.3) 🖼
 ✓ Preparing nodes 📦 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Joining worker nodes 🚜 
 ✓ Waiting ≤ 1m0s for control-plane = Ready ⏳ 
 • Ready after 0s 💚
Set kubectl context to "kind-chart-testing"
You can now use your cluster with:

kubectl cluster-info --context kind-chart-testing

Thanks for using kind! 😊
Copying kubeconfig to container...
Successfully copied 7.68kB to ct:/root/.kube/config
Kubernetes control plane is running at https://127.0.0.1:56353
CoreDNS is running at https://127.0.0.1:56353/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

NAME                          STATUS     ROLES           AGE   VERSION
chart-testing-control-plane   Ready      control-plane   29s   v1.25.3
chart-testing-worker          NotReady   <none>          5s    v1.25.3

Cluster ready!

Linting and installing charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 couchdb => (version: "4.5.4", path: "couchdb")
------------------------------------------------------------------------------------------------------------------------

Error: failed linting and installing charts: failed identifying merge base: must be in a git repository

------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
failed linting and installing charts: failed identifying merge base: must be in a git repository
Removing ct container...
Deleting cluster "chart-testing" ...
Deleted nodes: ["chart-testing-worker" "chart-testing-control-plane"]
Done!
make: *** [test] Error 1
```

</details>

I'm not sure what I'm doing wrong, help would be appreciated 🙏 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [x] NEWS.md updated
