### PR TITLE
Give the `Service` default port (5984) a name so that it is not ambiguous if `service.extraPorts` is used.

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.5.4
+version: 4.5.5
 appVersion: 3.3.3
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,9 @@
 # NEWS
 
+## 4.5.5
+
+- Give the default port on the CouchDB `Service` a name so that `service.extraPorts` can be used properly.
+
 ## 4.5.4
 
 - Expose `extraPorts` and `service.extraPorts` to allow specifying arbitrary ports to be exposed from the CouchDB pods

--- a/couchdb/templates/service.yaml
+++ b/couchdb/templates/service.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.service.externalPort }}
+      name: couchdb
       protocol: TCP
       targetPort: {{ .Values.service.targetPort }}
     {{ with .Values.service.extraPorts }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Sorry about this @willholley, but I noticed when trying to update to 4.5.4 and use my new `extraPorts` values that if you try to have multiple ports on a `Service` in Kubernetes, all ports need a `name` (https://github.com/kubernetes/kubernetes/issues/36803). If there's just one port, this `name` property is optional. Sadly this renders `service.extraPorts` useless in 4.5.4, so for 4.5.5 I've given the default port a name.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] ~~Variables are documented in the README.md~~ (no new variables)
- [x] NEWS.md updated
