### PR TITLE
Add extraPorts to the network policy when it is enabled.

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.5.5
+version: 4.5.6
 appVersion: 3.3.3
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,9 @@
 # NEWS
 
+## 4.5.6
+
+- Add `extraPorts` to the network policy when the network policy is enabled.
+
 ## 4.5.5
 
 - Give the default port on the CouchDB `Service` a name so that `service.extraPorts` can be used properly.

--- a/couchdb/templates/networkpolicy.yaml
+++ b/couchdb/templates/networkpolicy.yaml
@@ -21,6 +21,10 @@ spec:
         - protocol: TCP
           port: {{ .Values.prometheusPort.port }}
 {{- end }}
+{{ range .Values.extraPorts }}
+        - protocol: TCP
+          port: {{ .containerPort }} 
+{{ end }}
     - ports:
         - protocol: TCP
           port: 9100


### PR DESCRIPTION
#### What this PR does / why we need it:

I'm really sorry, I am about 99.9% sure this will be the last PR from us @willholley 🙈 

I completely missed the `NetworkPolicy` resource and have spent the afternoon wondering why I get no packets back from any requests to my newly-opened ports. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] ~~Variables are documented in the README.md~~ (no new variables)
- [x] NEWS.md updated
