### PR TITLE
Add extra EnvVars, VolumeMounts, Volumes and InitContainers to the STS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+*.tgz
+.idea/

--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -19,3 +19,9 @@ maintainers:
   - name: willholley
     email: willholley@apache.org
 icon: http://couchdb.apache.org/CouchDB-visual-identity/logo/CouchDB-couch-symbol.svg
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  tags:
+  - bitnami-common
+  version: 2.x.x

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,11 @@
 # NEWS
 
+## 4.5.7
+
+- Add `extraEnvVars` to the `couchdb` container in the StatefulSet.
+- Add `extraVolumeMounts` to the `couchdb` container in the StatefulSet
+- Add `extraVolumes` to the StatefulSet
+
 ## 4.5.6
 
 - Add `extraPorts` to the network policy when the network policy is enabled.

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -5,6 +5,7 @@
 - Add `extraEnvVars` to the `couchdb` container in the StatefulSet.
 - Add `extraVolumeMounts` to the `couchdb` container in the StatefulSet
 - Add `extraVolumes` to the StatefulSet
+- Add `extraInitContainers` to the StatefulSet
 
 ## 4.5.6
 

--- a/couchdb/requirements.lock
+++ b/couchdb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
-generated: "2024-07-04T16:05:12.128913+02:00"
+  version: 2.20.4
+digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
+generated: "2024-07-12T14:35:04.405255+02:00"

--- a/couchdb/requirements.lock
+++ b/couchdb/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.20.3
+digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
+generated: "2024-07-04T16:05:12.128913+02:00"

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -129,6 +129,9 @@ spec:
                   key: erlangCookie
             - name: ERL_FLAGS
               value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
+{{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+{{- end }}
 {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
 {{- if .Values.couchdbConfig.chttpd.require_valid_user }}
@@ -178,6 +181,9 @@ spec:
 {{- end }}
           - name: database-storage
             mountPath: /opt/couchdb/data
+{{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+{{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
@@ -225,6 +231,9 @@ spec:
 {{- if .Values.prometheusPort.enabled }}
               - key: prometheusinifile
                 path: prometheus.ini
+{{- end }}
+{{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
 {{- end }}
 
 {{- if .Values.adminHash }}

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -87,6 +87,9 @@ spec:
           resources:
 {{ toYaml .Values.initResources | indent 12 }}
 {{- end }}
+        {{- if .Values.extraInitContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraInitContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: couchdb
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -105,6 +105,9 @@ initImage:
   tag: latest
   pullPolicy: Always
 
+## Define extra init containers here. E.g. for copying custom configuration files
+extraInitContainers: []
+
 ## CouchDB is happy to spin up cluster nodes in parallel, but if you encounter
 ## problems you can try setting podManagementPolicy to the StatefulSet default
 ## `OrderedReady`

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -167,6 +167,25 @@ extraPorts: []
   # - name: sqs
   #   containerPort: 4984
 
+## Additional environment variables to set in the CouchDB container
+extraEnvVars: []
+  # - name: MY_ENV_VAR
+  #   value: my-env-var-value
+
+## If you need to mount extra volumes on the CouchDB container
+extraVolumeMounts:
+  # - name: limits-config
+  #   mountPath: /etc/security/limits.d
+
+## Define extra volumes for the StatefulSet here
+extraVolumes:
+  # - name: limits-config
+  #   configMap:
+  #     name: limits-config
+  #     items:
+  #       - key: 100-couchdb
+  #         path: 100-couchdb.conf
+
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed
 ## from outside the Kubernetes cluster.


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

This PR adds `extraEnvVars`, `extraVolumeMounts`, `extraVolumes` and `extraInitContainers` to the `values.yaml` and `StatefulSet`. The rendering of the values is performed with `bitnami/common`. This allows users of the Helm chart to better customize their CouchDB deployment.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - no issue has been opened to my knowledge

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [ ] Chart Version bumped
- [ ] e2e tests pass
- [ ] Variables are documented in the README.md
- [ ] NEWS.md updated
