### PR TITLE
Make `erlangCookie` and `cookieAuthSecret` specifiable in `extraSecret`

### DIFF
--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.6.1
+version: 4.6.2
 appVersion: 3.5.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,5 +1,8 @@
 # NEWS
 
+## 4.6.2
+- Added options to specify `erlangCookie` and `cookieAuthSecret` within the extra secret
+
 ## 4.6.1
 - Update default CouchDB version to 3.5.0
 

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -173,6 +173,8 @@ A variety of other parameters are also configurable. See the comments in the
 | `extraSecretName`                    | "" (the name of a secret resource to provide e.g. admin credentials from an ExternalSecret/vault/etc.)     |
 | `adminUsernameKey`                   | "" (the string/key to access the admin username secret from an extra secret if different from "adminUsername"  |
 | `adminPasswordKey`                   | "" (the string/key to access the admin password secret from an extra secret if different from "adminPassword"  |
+| `cookieAuthSecretKey`                | "" (the string/key to access the cookie auth secret from an extra secret if different from "cookieAuthSecret"  |
+| `erlangCookieKey`                    | "" (the string/key to access the erlang cookie secret from an extra secret if different from "erlangCookie"  |
 | `cookieAuthSecret`                   | auto-generated                                   |
 | `extraPorts`                         | [] (a list of ContainerPort objects)             |
 | `image.repository`                   | couchdb                                          |

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,6 @@
 # CouchDB
 
-![Version: 4.6.1](https://img.shields.io/badge/Version-4.6.1-informational?style=flat-square) ![AppVersion: 3.5.0](https://img.shields.io/badge/AppVersion-3.5.0-informational?style=flat-square)
+![Version: 4.6.2](https://img.shields.io/badge/Version-4.6.2-informational?style=flat-square) ![AppVersion: 3.5.0](https://img.shields.io/badge/AppVersion-3.5.0-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -18,7 +18,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
-  --version=4.6.1 \
+  --version=4.6.2 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -44,7 +44,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.6.1 \
+  --version=4.6.2 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -78,7 +78,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.6.1 \
+  --version=4.6.2 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -133,7 +133,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=4.6.1 couchdb/couchdb
+$ helm upgrade my-release --version=4.6.2 couchdb/couchdb
 ```
 
 ## Configuration

--- a/couchdb/templates/statefulset.yaml
+++ b/couchdb/templates/statefulset.yaml
@@ -125,14 +125,14 @@ spec:
             - name: COUCHDB_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "couchdb.fullname" . }}
-                  key: cookieAuthSecret
+                  name: {{ .Values.extraSecretName | default (include "couchdb.fullname" .) }}
+                  key: {{ .Values.cookieAuthSecretKey | default "cookieAuthSecret" }}
 {{- end }}
             - name: COUCHDB_ERLANG_COOKIE
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "couchdb.fullname" . }}
-                  key: erlangCookie
+                  name: {{ .Values.extraSecretName | default (include "couchdb.fullname" .) }}
+                  key: {{ .Values.erlangCookieKey | default "erlangCookie" }}
             - name: ERL_FLAGS
               value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
 {{- if .Values.extraEnv }}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -40,6 +40,8 @@ createAdminSecret: true
 extraSecretName: ""
 adminUsernameKey: ""
 adminPasswordKey: ""
+cookieAuthSecretKey: ""
+erlangCookieKey: ""
 
 adminUsername: admin
 # adminPassword: this_is_not_secure


### PR DESCRIPTION
<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:
This PR fixes an issue where a user attempting to use their own secret with `extraSecretName` and disabling `createAdminSecret` encounters an error during deployment. The error occurs because the chart expects `cookieAuthSecret` and `erlangCookie` to exist, but the secrets are not found.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [ ] e2e tests pass
- [x] Variables are documented in the README.md
- [x] NEWS.md updated
