### PR TITLE
feat: add configurable backoffLimit for autoSetup job

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,9 @@ history. This will make it easier to identify new changes. The PR will be squash
 anyways when it is merged. Thanks.
 
 Please make sure you test your changes before you push them.
+
+If you modified values.yaml or README.md.gotmpl, regenerate the README.md:
+  helm-docs -c couchdb -t ../_templates.gotmpl -t README.md.gotmpl
 -->
 
 #### What this PR does / why we need it:

--- a/couchdb/Chart.yaml
+++ b/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 4.6.3
+version: 4.6.4
 appVersion: 3.5.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/couchdb/NEWS.md
+++ b/couchdb/NEWS.md
@@ -1,12 +1,22 @@
 # NEWS
 
+## 4.6.4
+
+- Added configurable backoffLimit for autoSetup job
+- Update chart-testing version to v3.14.0
+- Update KinD version to v0.31.0
+- Update Kubernetes version for testing to v1.35.1
+
 ## 4.6.3
+
 - Update default CouchDB version to 3.5.1
 
 ## 4.6.2
+
 - Added options to specify `erlangCookie` and `cookieAuthSecret` within the extra secret
 
 ## 4.6.1
+
 - Update default CouchDB version to 3.5.0
 
 ## 4.5.7
@@ -57,7 +67,7 @@
 
 - Simplified the `adminHash` in the secret
 
-# 3.6.4
+## 3.6.4
 
 - Add `service.labels` value to pass along labels to the client-facing service
 - Update `ingress` to use the service created by `service.enabled=true`,
@@ -65,7 +75,7 @@
   ([#94](https://github.com/apache/couchdb-helm/issues/94))
   - This allows setting `service.annotations`, `service.labels`, etc. in a way that will be picked up by the ingress
 
-# 3.6.3
+## 3.6.3
 
 - Add PersistentVolume annotations
 

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -1,6 +1,7 @@
+
 # CouchDB
 
-![Version: 4.6.3](https://img.shields.io/badge/Version-4.6.3-informational?style=flat-square) ![AppVersion: 3.5.1](https://img.shields.io/badge/AppVersion-3.5.1-informational?style=flat-square)
+![Version: 4.6.4](https://img.shields.io/badge/Version-4.6.4-informational?style=flat-square) ![AppVersion: 3.5.1](https://img.shields.io/badge/AppVersion-3.5.1-informational?style=flat-square)
 
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -18,7 +19,7 @@ storage volumes to each Pod in the Deployment.
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
 $ helm install couchdb/couchdb \
-  --version=4.6.3 \
+  --version=4.6.4 \
   --set allowAdminParty=true \
   --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
@@ -44,7 +45,7 @@ Afterwards install the chart replacing the UUID
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.6.3 \
+  --version=4.6.4 \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
 ```
@@ -78,7 +79,7 @@ and then install the chart while overriding the `createAdminSecret` setting:
 ```bash
 $ helm install \
   --name my-release \
-  --version=4.6.3 \
+  --version=4.6.4 \
   --set createAdminSecret=false \
   --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
   couchdb/couchdb
@@ -133,7 +134,7 @@ version semantics. You can upgrade directly from `stable/couchdb` to this chart 
 
 ```bash
 $ helm repo add couchdb https://apache.github.io/couchdb-helm
-$ helm upgrade my-release --version=4.6.3 couchdb/couchdb
+$ helm upgrade my-release --version=4.6.4 couchdb/couchdb
 ```
 
 ## Configuration
@@ -146,10 +147,10 @@ CouchDB chart and their default values:
 | allowAdminParty | bool | `false` | If allowAdminParty is enabled the cluster will start up without any database administrator account; i.e., all users will be granted administrative access. Otherwise, the system will look for a Secret called <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys. See the `createAdminSecret` flag. ref: https://kubernetes.io/docs/concepts/configuration/secret/ |
 | clusterSize | int | `3` | the initial number of nodes in the CouchDB cluster. |
 | couchdbConfig | object | `{"chttpd":{"bind_address":"any","require_valid_user":false}}` | couchdbConfig will override default CouchDB configuration settings. The contents of this map are reformatted into a .ini file laid down by a ConfigMap object. ref: http://docs.couchdb.org/en/latest/config/index.html |
-| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options: 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace. 2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
+| createAdminSecret | bool | `true` | If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will be created containing auto-generated credentials. Users who prefer to set these values themselves have a couple of options:  1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`    can be defined directly in the chart's values. Note that all of a chart's    values are currently stored in plaintext in a ConfigMap in the tiller    namespace.  2) This flag can be disabled and a Secret with the required keys can be    created ahead of time. |
 | enableSearch | bool | `false` | Flip this to flag to include the Search container in each Pod |
 | erlangFlags | object | `{"name":"couchdb"}` | erlangFlags is a map that is passed to the Erlang VM as flags using the ERL_FLAGS env. The `name` flag is required to establish connectivity between cluster nodes. ref: http://erlang.org/doc/man/erl.html#init_flags |
-| persistentVolume | object | `{"accessModes":["ReadWriteOnce"],"enabled":false,"size":"10Gi"}` | The storage volume used by each Pod in the StatefulSet. If a persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral local storage. Setting the storageClass attribute to "-" disables dynamic provisioning of Persistent Volumes; leaving it unset will invoke the default provisioner. |
+| persistentVolume | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaims":[],"size":"10Gi"}` | The storage volume used by each Pod in the StatefulSet. If a persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral local storage. Setting the storageClass attribute to "-" disables dynamic provisioning of Persistent Volumes; leaving it unset will invoke the default provisioner. |
 
 You can set the values of the `couchdbConfig` map according to the
 [official configuration][4]. The following shows the map's default values and
@@ -164,97 +165,96 @@ required options to set:
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
-
-| Parameter                            | Default                                          |
-|--------------------------------------| ------------------------------------------------ |
-| `adminUsername`                      | admin                                            |
-| `adminPassword`                      | auto-generated                                   |
-| `adminHash`                          |                                                  |
-| `extraSecretName`                    | "" (the name of a secret resource to provide e.g. admin credentials from an ExternalSecret/vault/etc.)     |
-| `adminUsernameKey`                   | "" (the string/key to access the admin username secret from an extra secret if different from "adminUsername"  |
-| `adminPasswordKey`                   | "" (the string/key to access the admin password secret from an extra secret if different from "adminPassword"  |
-| `cookieAuthSecretKey`                | "" (the string/key to access the cookie auth secret from an extra secret if different from "cookieAuthSecret"  |
-| `erlangCookieKey`                    | "" (the string/key to access the erlang cookie secret from an extra secret if different from "erlangCookie"  |
-| `cookieAuthSecret`                   | auto-generated                                   |
-| `extraPorts`                         | [] (a list of ContainerPort objects)             |
-| `image.repository`                   | couchdb                                          |
-| `image.tag`                          | 3.5.1                                            |
-| `image.pullPolicy`                   | IfNotPresent                                     |
-| `searchImage.repository`             | kocolosk/couchdb-search                          |
-| `searchImage.tag`                    | 0.1.0                                            |
-| `searchImage.pullPolicy`             | IfNotPresent                                     |
-| `initImage.repository`               | busybox                                          |
-| `initImage.tag`                      | latest                                           |
-| `initImage.pullPolicy`               | Always                                           |
-| `ingress.enabled`                    | false                                            |
-| `ingress.className`                  |                                                  |
-| `ingress.hosts`                      | chart-example.local                              |
-| `ingress.annotations`                |                                                  |
-| `ingress.path`                       | /                                                |
-| `ingress.tls`                        |                                                  |
-| `persistentVolume.accessModes`       | ReadWriteOnce                                    |
-| `persistentVolume.storageClass`      | Default for the Kube cluster                     |
-| `persistentVolume.annotations`       | {}                                               |
-| `persistentVolume.existingClaims`    | [] (a list of existing PV/PVC volume value objects with `volumeName`, `claimName`, `persistentVolumeName` and `volumeSource` defined)                                                                |
-| `persistentVolume.volumeName`        |                                                  |
-| `persistentVolume.claimName`         |                                                  |
-| `persistentVolume.volumeSource`      |                                                  |
-| `persistentVolume.annotations`       | {}                                               |
-| `persistentVolumeClaimRetentionPolicy.enabled`     | Field controls if and how PVCs are deleted during the lifecycle                                            |
+| Parameter                            | Default                                                                                                                                                      |
+|--------------------------------------| -------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `adminUsername`                      | admin                                                                                                                                                        |
+| `adminPassword`                      | auto-generated                                                                                                                                               |
+| `adminHash`                          |                                                                                                                                                              |
+| `extraSecretName`                    | "" (the name of a secret resource to provide e.g. admin credentials from an ExternalSecret/vault/etc.)                                                       |
+| `adminUsernameKey`                   | "" (the string/key to access the admin username secret from an extra secret if different from "adminUsername"                                                 |
+| `adminPasswordKey`                   | "" (the string/key to access the admin password secret from an extra secret if different from "adminPassword"                                                 |
+| `cookieAuthSecretKey`                | "" (the string/key to access the cookie auth secret from an extra secret if different from "cookieAuthSecret"                                                 |
+| `erlangCookieKey`                    | "" (the string/key to access the erlang cookie secret from an extra secret if different from "erlangCookie"                                                   |
+| `cookieAuthSecret`                   | auto-generated                                                                                                                                               |
+| `extraPorts`                         | [] (a list of ContainerPort objects)                                                                                                                         |
+| `image.repository`                   | couchdb                                                                                                                                                      |
+| `image.tag`                          | 3.5.1                                                                                                                                                        |
+| `image.pullPolicy`                   | IfNotPresent                                                                                                                                                 |
+| `searchImage.repository`             | kocolosk/couchdb-search                                                                                                                                      |
+| `searchImage.tag`                    | 0.2.0                                                                                                                                                        |
+| `searchImage.pullPolicy`             | IfNotPresent                                                                                                                                                 |
+| `initImage.repository`               | busybox                                                                                                                                                      |
+| `initImage.tag`                      | latest                                                                                                                                                       |
+| `initImage.pullPolicy`               | Always                                                                                                                                                       |
+| `ingress.enabled`                    | false                                                                                                                                                        |
+| `ingress.className`                  |                                                                                                                                                              |
+| `ingress.hosts`                      | chart-example.local                                                                                                                                          |
+| `ingress.annotations`                |                                                                                                                                                              |
+| `ingress.path`                       | /                                                                                                                                                            |
+| `ingress.tls`                        |                                                                                                                                                              |
+| `persistentVolume.accessModes`       | ReadWriteOnce                                                                                                                                                |
+| `persistentVolume.storageClass`      | Default for the Kube cluster                                                                                                                                 |
+| `persistentVolume.annotations`       | {}                                                                                                                                                           |
+| `persistentVolume.existingClaims`    | [] (a list of existing PV/PVC volume value objects with `volumeName`, `claimName`, `persistentVolumeName` and `volumeSource` defined)                         |
+| `persistentVolume.volumeName`        |                                                                                                                                                              |
+| `persistentVolume.claimName`         |                                                                                                                                                              |
+| `persistentVolume.volumeSource`      |                                                                                                                                                              |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Field controls if and how PVCs are deleted during the lifecycle                                                                                |
 | `persistentVolumeClaimRetentionPolicy.whenScaled`  | Configures the volume retention behavior that applies when the replica count of the StatefulSet is reduced |
 | `persistentVolumeClaimRetentionPolicy.whenDeleted` | Configures the volume retention behavior that applies when the StatefulSet is deleted                      |
-| `podDisruptionBudget.enabled`        | false                                            |
-| `podDisruptionBudget.minAvailable`   | nil                                              |
-| `podDisruptionBudget.maxUnavailable` | 1                                                |
-| `podManagementPolicy`                | Parallel                                         |
-| `affinity`                           |                                                  |
-| `topologySpreadConstraints`          |                                                  |
-| `labels`                             |                                                  |
-| `annotations`                        |                                                  |
-| `tolerations`                        |                                                  |
-| `resources`                          |                                                  |
-| `initResources`                      |                                                  |
-| `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure)                                         |
-| `autoSetup.image.repository`         | curlimages/curl                                  |
-| `autoSetup.image.tag`                | latest                                           |
-| `autoSetup.image.pullPolicy`         | Always                                           |
-| `autoSetup.defaultDatabases`         | [`_global_changes`]                              |
-| `service.annotations`                |                                                  |
-| `service.enabled`                    | true                                             |
-| `service.type`                       | ClusterIP                                        |
-| `service.externalPort`               | 5984                                             |
-| `service.targetPort`                 | 5984                                             |
-| `service.extraPorts`                 | [] (a list of ServicePort objects)               |
-| `dns.clusterDomainSuffix`            | cluster.local                                    |
-| `networkPolicy.enabled`              | true                                             |
-| `serviceAccount.enabled`             | true                                             |
-| `serviceAccount.create`              | true                                             |
-| `imagePullSecrets`                   |                                                  |
-| `sidecars`                           | {}                                               |
-| `livenessProbe.enabled`              | true                                             |
-| `livenessProbe.failureThreshold`     | 3                                                |
-| `livenessProbe.initialDelaySeconds`  | 0                                                |
-| `livenessProbe.periodSeconds`        | 10                                               |
-| `livenessProbe.successThreshold`     | 1                                                |
-| `livenessProbe.timeoutSeconds`       | 1                                                |
-| `readinessProbe.enabled`             | true                                             |
-| `readinessProbe.failureThreshold`    | 3                                                |
-| `readinessProbe.initialDelaySeconds` | 0                                                |
-| `readinessProbe.periodSeconds`       | 10                                               |
-| `readinessProbe.successThreshold`    | 1                                                |
-| `readinessProbe.timeoutSeconds`      | 1                                                |
-| `prometheusPort.enabled`             | false                                            |
-| `prometheusPort.port`                | 17896                                            |
-| `prometheusPort.bind_address`        | 0.0.0.0                                          |
-| `lifecycle`                          | {}                                               |
-| `lifecycleTemplate`                  | false (set `true` and add a named `lifecycleTemplate` if using couchdb as a subchart) |
-| `extraEnv`                           | []                                               |
-| `extraEnvTemplate`                   | false (set `true` and add a named `extraEnvTemplate` if using couchdb as a subchart) |
-| `placementConfig.enabled`            | false                                            |
-| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager  |
-| `placementConfig.image.tag`          | 0.1.0                                            |
-| `podSecurityContext`                 |                                                  |
-| `containerSecurityContext`           |                                                  |
+| `podDisruptionBudget.enabled`        | false                                                                                                                                                        |
+| `podDisruptionBudget.minAvailable`   | nil                                                                                                                                                          |
+| `podDisruptionBudget.maxUnavailable` | 1                                                                                                                                                            |
+| `podManagementPolicy`                | Parallel                                                                                                                                                     |
+| `affinity`                           |                                                                                                                                                              |
+| `topologySpreadConstraints`          |                                                                                                                                                              |
+| `labels`                             |                                                                                                                                                              |
+| `annotations`                        |                                                                                                                                                              |
+| `tolerations`                        |                                                                                                                                                              |
+| `resources`                          |                                                                                                                                                              |
+| `initResources`                      |                                                                                                                                                              |
+| `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure) |
+| `autoSetup.image.repository`         | curlimages/curl                                                                                                                                              |
+| `autoSetup.image.tag`                | latest                                                                                                                                                       |
+| `autoSetup.image.pullPolicy`         | Always                                                                                                                                                       |
+| `autoSetup.defaultDatabases`         | [`_global_changes`]                                                                                                                                          |
+| `autoSetup.backoffLimit`             | 2                                                                                                                                                            |
+| `service.annotations`                |                                                                                                                                                              |
+| `service.enabled`                    | true                                                                                                                                                         |
+| `service.type`                       | ClusterIP                                                                                                                                                    |
+| `service.externalPort`               | 5984                                                                                                                                                         |
+| `service.targetPort`                 | 5984                                                                                                                                                         |
+| `service.extraPorts`                 | [] (a list of ServicePort objects)                                                                                                                           |
+| `dns.clusterDomainSuffix`            | cluster.local                                                                                                                                                |
+| `networkPolicy.enabled`              | true                                                                                                                                                         |
+| `serviceAccount.enabled`             | true                                                                                                                                                         |
+| `serviceAccount.create`              | true                                                                                                                                                         |
+| `imagePullSecrets`                   |                                                                                                                                                              |
+| `sidecars`                           | {}                                                                                                                                                           |
+| `livenessProbe.enabled`              | true                                                                                                                                                         |
+| `livenessProbe.failureThreshold`     | 3                                                                                                                                                            |
+| `livenessProbe.initialDelaySeconds`  | 0                                                                                                                                                            |
+| `livenessProbe.periodSeconds`        | 10                                                                                                                                                           |
+| `livenessProbe.successThreshold`     | 1                                                                                                                                                            |
+| `livenessProbe.timeoutSeconds`       | 1                                                                                                                                                            |
+| `readinessProbe.enabled`             | true                                                                                                                                                         |
+| `readinessProbe.failureThreshold`    | 3                                                                                                                                                            |
+| `readinessProbe.initialDelaySeconds` | 0                                                                                                                                                            |
+| `readinessProbe.periodSeconds`       | 10                                                                                                                                                           |
+| `readinessProbe.successThreshold`    | 1                                                                                                                                                            |
+| `readinessProbe.timeoutSeconds`      | 1                                                                                                                                                            |
+| `prometheusPort.enabled`             | false                                                                                                                                                        |
+| `prometheusPort.port`                | 17986                                                                                                                                                        |
+| `prometheusPort.bind_address`        | 0.0.0.0                                                                                                                                                      |
+| `lifecycle`                          | {}                                                                                                                                                           |
+| `lifecycleTemplate`                  | false (set `true` and add a named `lifecycleTemplate` if using couchdb as a subchart)                                                                        |
+| `extraEnv`                           | []                                                                                                                                                           |
+| `extraEnvTemplate`                   | false (set `true` and add a named `extraEnvTemplate` if using couchdb as a subchart)                                                                         |
+| `placementConfig.enabled`            | false                                                                                                                                                        |
+| `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager                                                                                                              |
+| `placementConfig.image.tag`          | 0.1.0                                                                                                                                                        |
+| `podSecurityContext`                 |                                                                                                                                                              |
+| `containerSecurityContext`           |                                                                                                                                                              |
 
 ## Feedback, Issues, Contributing
 

--- a/couchdb/README.md.gotmpl
+++ b/couchdb/README.md.gotmpl
@@ -109,7 +109,7 @@ incompatible breaking change needing manual actions.
 ### Upgrade to 3.0.0
 
 Since version 3.0.0 setting the CouchDB server instance UUID is mandatory.
-Therefore you need to generate a UUID and supply it as a value during the
+Therefore, you need to generate a UUID and supply it as a value during the
 upgrade as follows:
 
 ```bash
@@ -156,22 +156,30 @@ required options to set:
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
+
 | Parameter                            | Default                                                                                                                                                      |
-|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|--------------------------------------| -------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `adminUsername`                      | admin                                                                                                                                                        |
 | `adminPassword`                      | auto-generated                                                                                                                                               |
 | `adminHash`                          |                                                                                                                                                              |
+| `extraSecretName`                    | "" (the name of a secret resource to provide e.g. admin credentials from an ExternalSecret/vault/etc.)                                                       |
+| `adminUsernameKey`                   | "" (the string/key to access the admin username secret from an extra secret if different from "adminUsername"                                                 |
+| `adminPasswordKey`                   | "" (the string/key to access the admin password secret from an extra secret if different from "adminPassword"                                                 |
+| `cookieAuthSecretKey`                | "" (the string/key to access the cookie auth secret from an extra secret if different from "cookieAuthSecret"                                                 |
+| `erlangCookieKey`                    | "" (the string/key to access the erlang cookie secret from an extra secret if different from "erlangCookie"                                                   |
 | `cookieAuthSecret`                   | auto-generated                                                                                                                                               |
+| `extraPorts`                         | [] (a list of ContainerPort objects)                                                                                                                         |
 | `image.repository`                   | couchdb                                                                                                                                                      |
 | `image.tag`                          | 3.5.1                                                                                                                                                        |
 | `image.pullPolicy`                   | IfNotPresent                                                                                                                                                 |
 | `searchImage.repository`             | kocolosk/couchdb-search                                                                                                                                      |
-| `searchImage.tag`                    | 0.1.0                                                                                                                                                        |
+| `searchImage.tag`                    | 0.2.0                                                                                                                                                        |
 | `searchImage.pullPolicy`             | IfNotPresent                                                                                                                                                 |
 | `initImage.repository`               | busybox                                                                                                                                                      |
 | `initImage.tag`                      | latest                                                                                                                                                       |
 | `initImage.pullPolicy`               | Always                                                                                                                                                       |
 | `ingress.enabled`                    | false                                                                                                                                                        |
+| `ingress.className`                  |                                                                                                                                                              |
 | `ingress.hosts`                      | chart-example.local                                                                                                                                          |
 | `ingress.annotations`                |                                                                                                                                                              |
 | `ingress.path`                       | /                                                                                                                                                            |
@@ -179,6 +187,13 @@ A variety of other parameters are also configurable. See the comments in the
 | `persistentVolume.accessModes`       | ReadWriteOnce                                                                                                                                                |
 | `persistentVolume.storageClass`      | Default for the Kube cluster                                                                                                                                 |
 | `persistentVolume.annotations`       | {}                                                                                                                                                           |
+| `persistentVolume.existingClaims`    | [] (a list of existing PV/PVC volume value objects with `volumeName`, `claimName`, `persistentVolumeName` and `volumeSource` defined)                         |
+| `persistentVolume.volumeName`        |                                                                                                                                                              |
+| `persistentVolume.claimName`         |                                                                                                                                                              |
+| `persistentVolume.volumeSource`      |                                                                                                                                                              |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Field controls if and how PVCs are deleted during the lifecycle                                                                                |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Configures the volume retention behavior that applies when the replica count of the StatefulSet is reduced |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Configures the volume retention behavior that applies when the StatefulSet is deleted                      |
 | `podDisruptionBudget.enabled`        | false                                                                                                                                                        |
 | `podDisruptionBudget.minAvailable`   | nil                                                                                                                                                          |
 | `podDisruptionBudget.maxUnavailable` | 1                                                                                                                                                            |
@@ -189,21 +204,24 @@ A variety of other parameters are also configurable. See the comments in the
 | `annotations`                        |                                                                                                                                                              |
 | `tolerations`                        |                                                                                                                                                              |
 | `resources`                          |                                                                                                                                                              |
+| `initResources`                      |                                                                                                                                                              |
 | `autoSetup.enabled`                  | false (if set to true, must have `service.enabled` set to true and a correct `adminPassword` - deploy it with the `--wait` flag to avoid first jobs failure) |
-| `autoSetup.image.repository`         | alpine/curl                                                                                                                                                  |
+| `autoSetup.image.repository`         | curlimages/curl                                                                                                                                              |
 | `autoSetup.image.tag`                | latest                                                                                                                                                       |
 | `autoSetup.image.pullPolicy`         | Always                                                                                                                                                       |
 | `autoSetup.defaultDatabases`         | [`_global_changes`]                                                                                                                                          |
+| `autoSetup.backoffLimit`             | 2                                                                                                                                                            |
 | `service.annotations`                |                                                                                                                                                              |
 | `service.enabled`                    | true                                                                                                                                                         |
 | `service.type`                       | ClusterIP                                                                                                                                                    |
 | `service.externalPort`               | 5984                                                                                                                                                         |
 | `service.targetPort`                 | 5984                                                                                                                                                         |
+| `service.extraPorts`                 | [] (a list of ServicePort objects)                                                                                                                           |
 | `dns.clusterDomainSuffix`            | cluster.local                                                                                                                                                |
 | `networkPolicy.enabled`              | true                                                                                                                                                         |
 | `serviceAccount.enabled`             | true                                                                                                                                                         |
 | `serviceAccount.create`              | true                                                                                                                                                         |
-| `serviceAccount.imagePullSecrets`    |                                                                                                                                                              |
+| `imagePullSecrets`                   |                                                                                                                                                              |
 | `sidecars`                           | {}                                                                                                                                                           |
 | `livenessProbe.enabled`              | true                                                                                                                                                         |
 | `livenessProbe.failureThreshold`     | 3                                                                                                                                                            |
@@ -218,13 +236,17 @@ A variety of other parameters are also configurable. See the comments in the
 | `readinessProbe.successThreshold`    | 1                                                                                                                                                            |
 | `readinessProbe.timeoutSeconds`      | 1                                                                                                                                                            |
 | `prometheusPort.enabled`             | false                                                                                                                                                        |
-| `prometheusPort.port`                | 17896                                                                                                                                                        |
+| `prometheusPort.port`                | 17986                                                                                                                                                        |
 | `prometheusPort.bind_address`        | 0.0.0.0                                                                                                                                                      |
+| `lifecycle`                          | {}                                                                                                                                                           |
+| `lifecycleTemplate`                  | false (set `true` and add a named `lifecycleTemplate` if using couchdb as a subchart)                                                                        |
+| `extraEnv`                           | []                                                                                                                                                           |
+| `extraEnvTemplate`                   | false (set `true` and add a named `extraEnvTemplate` if using couchdb as a subchart)                                                                         |
 | `placementConfig.enabled`            | false                                                                                                                                                        |
 | `placementConfig.image.repository`   | caligrafix/couchdb-autoscaler-placement-manager                                                                                                              |
 | `placementConfig.image.tag`          | 0.1.0                                                                                                                                                        |
 | `podSecurityContext`                 |                                                                                                                                                              |
-| `containerSecurityContext            |                                                                                                                                                              |
+| `containerSecurityContext`           |                                                                                                                                                              |
 
 ## Feedback, Issues, Contributing
 
@@ -251,6 +273,7 @@ use GitHub Issues, do not report anything on Docker's website.
 - [@kevinwlau](https://github.com/kevinwlau)
 - [@jeyenzo](https://github.com/jeyenzo)
 - [@Pinpin31.](https://github.com/Pinpin31)
+- [@yekibud](https://github.com/yekibud)
 
 [1]: http://mail-archives.apache.org/mod_mbox/couchdb-user/
 [2]: http://mail-archives.apache.org/mod_mbox/couchdb-dev/

--- a/couchdb/templates/job.yaml
+++ b/couchdb/templates/job.yaml
@@ -50,7 +50,7 @@ spec:
           {{- if .Values.containerSecurityContext }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
-  backoffLimit: 2
+  backoffLimit: {{ .Values.autoSetup.backoffLimit | default 2 }}
   ttlSecondsAfterFinished: 600
 {{- end -}}
 {{- end -}}

--- a/couchdb/values.yaml
+++ b/couchdb/values.yaml
@@ -23,6 +23,7 @@ autoSetup:
     pullPolicy: Always
   defaultDatabases:
     - _global_changes
+  backoffLimit: 2
 
 # -- If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will
 # be created containing auto-generated credentials. Users who prefer to set

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -1,1 +1,2 @@
 helm-extra-args: --timeout 800s
+validate-maintainers: false

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -4,10 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v3.11.0
-readonly KIND_VERSION=v0.23.0
+readonly CT_VERSION=v3.14.0
+readonly KIND_VERSION=v0.31.0
 readonly CLUSTER_NAME=chart-testing
-readonly K8S_VERSION=v1.25.3
+readonly K8S_VERSION=v1.35.1
 
 run_ct_container() {
     echo 'Running ct container...'
@@ -61,6 +61,7 @@ create_kind_cluster() {
 }
 
 install_charts() {
+    docker_exec git config --global --add safe.directory /workdir
     docker_exec ct lint-and-install --charts couchdb --upgrade --chart-dirs .
     echo
 }


### PR DESCRIPTION
chore: update chart-testing version to v3.14.0
chore: update KinD version to v0.31.0
chore: update Kubernetes version for testing to v1.35.1
chore: add missing values in README.md.gotmpl

fixes: #254

<!--
Thank you for contributing to couchdb-helm. Before you submit this PR we'd like to
make sure you are aware of the chart technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

Wanted to test your Chart for the first time and the post install job fails, as the couchdb wasn't ready initializing, so i wanted to make backoffLimit variable.
I also saw a bunch of outdated versions in the e2e test and updated them
And the Readme.md.gotmpl did not fit the Readme.md anymore.

had to set validate-maintainers: false as the e2e test failed otherwise on my local machine, as it tried to reach localhost on port 53 and i do not run a local dns service.

#### Which issue this PR fixes

#254 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
- [x] Chart Version bumped
- [x] e2e tests pass
- [x] Variables are documented in the README.md
- [x] NEWS.md updated



E2E test results (local)

------------------------------------------------------------------------------------------------------------------------
 ✔︎ couchdb => (version: "4.6.4", path: "couchdb")
------------------------------------------------------------------------------------------------------------------------
All charts linted and installed successfully